### PR TITLE
PCM-1426 PCM-1428 fixed sys default mic switch in chrome. added devices logging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v4.1.0...HEAD)
 
+### Fixed
+* [PCM-1428](https://inindca.atlassian.net/browse/PCM-1428) – in chrome, if you were using the system default audio device and then changed the default on the system level, the sdk would not start a audio with the new system default. 
+
+### Added 
+* [PCM-1426](https://inindca.atlassian.net/browse/PCM-1426) – better logging around devices. It will log devices in use we a session starts and when the devices change. 
+
+
 # [v4.1.0](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v4.0.1...v4.1.0)
 ### Added
 * added client logger to spigot tests for test debugability

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:unit": "NODE_ENV=test jest --runInBand",
     "test:watch": "jest --watch --collectCoverage=false --runInBand",
     "lint": "npm run tslint",
+    "lint:fix": "npm run tslint:fix",
     "tslint": "tslint --project . --config tslint.json",
     "tslint:fix": "tslint --project . --config tslint.json --fix",
     "greenkeep": "npx npm-check --update",

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -1,7 +1,7 @@
 import BaseSessionHandler from './base-session-handler';
 import { IPendingSession, IAcceptSessionRequest, ISessionMuteRequest, IConversationParticipant, IJingleSession } from '../types/interfaces';
 import { SessionTypes, LogLevels, SdkErrorTypes } from '../types/enums';
-import { attachAudioMedia, startMedia } from '../media-utils';
+import { attachAudioMedia, startMedia, logDeviceChange } from '../media-utils';
 import { requestApi, throwSdkError, isSoftphoneJid } from '../utils';
 import { pick } from 'lodash';
 
@@ -47,7 +47,8 @@ export default class SoftphoneSessionHandler extends BaseSessionHandler {
       });
     }
 
-    return super.acceptSession(session, params);
+    await super.acceptSession(session, params);
+    logDeviceChange(this.sdk, session, 'sessionStarted');
   }
 
   async endSession (session: IJingleSession): Promise<void> {

--- a/src/sessions/video-session-handler.ts
+++ b/src/sessions/video-session-handler.ts
@@ -15,7 +15,7 @@ import {
 } from '../types/interfaces';
 import BaseSessionHandler from './base-session-handler';
 import { SessionTypes, LogLevels, SdkErrorTypes, CommunicationStates } from '../types/enums';
-import { createNewStreamWithTrack, startMedia, startDisplayMedia, getEnumeratedDevices } from '../media-utils';
+import { createNewStreamWithTrack, startMedia, startDisplayMedia, getEnumeratedDevices, logDeviceChange } from '../media-utils';
 import { throwSdkError, requestApi, isVideoJid, isPeerVideoJid } from '../utils';
 import { ConversationUpdate } from '../types/conversation-update';
 
@@ -308,6 +308,8 @@ export default class VideoSessionHandler extends BaseSessionHandler {
 
     await super.acceptSession(session, params);
     this.setInitialMuteStates(session);
+
+    logDeviceChange(this.sdk, session, 'sessionStarted');
   }
 
   setInitialMuteStates (session: IJingleSession): void {
@@ -318,6 +320,8 @@ export default class VideoSessionHandler extends BaseSessionHandler {
       session.videoMuted = true;
       this.log(LogLevels.info, 'Sending initial video mute', { conversationId: session.conversationId });
       session.mute(userId, 'video');
+    } else {
+      session.videoMuted = false;
     }
 
     const audioSender = session.pc.getSenders().find((sender) => sender.track && sender.track.kind === 'audio');
@@ -325,6 +329,8 @@ export default class VideoSessionHandler extends BaseSessionHandler {
       session.audioMuted = true;
       this.log(LogLevels.info, 'Sending initial audio mute', { conversationId: session.conversationId });
       session.mute(userId, 'audio');
+    } else {
+      session.audioMuted = false;
     }
   }
 

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -162,6 +162,9 @@ class MockStream {
   getVideoTracks () {
     return this.getTracks().filter((t) => t.kind === 'video');
   }
+  getAudioTracks () {
+    return this.getTracks().filter((t) => t.kind === 'audio');
+  }
   getTracks () {
     return this._tracks;
   }

--- a/test/unit/sessions/base-session-handler.test.ts
+++ b/test/unit/sessions/base-session-handler.test.ts
@@ -368,12 +368,16 @@ describe('updateOutputDevice()', () => {
     const session = new MockSession();
     const deviceId = 'new-output-device';
     const spy = jest.fn();
+    jest.spyOn(mediaUtils, 'logDeviceChange').mockImplementation();
+
     session._outputAudioElement = { setSinkId: spy };
 
     await handler.updateOutputDevice(session as any, deviceId);
-    expect(mockSdk.logger.info).toHaveBeenCalledWith(
-      'Setting output deviceId',
-      { deviceId, conversationId: session.conversationId, sessionId: session.id }
+    expect(mediaUtils.logDeviceChange).toHaveBeenCalledWith(
+      mockSdk,
+      session,
+      'changingDevices',
+      { toOutputDeviceId: deviceId }
     );
     expect(spy).toHaveBeenCalledWith(deviceId);
   });
@@ -641,7 +645,10 @@ describe('_warnNegotiationNeeded', () => {
     const session = new MockSession();
     handler._warnNegotiationNeeded(session as any);
 
-    expect(mockSdk.logger.error).toHaveBeenCalledWith(expect.stringContaining('negotiation needed and not supported'), { conversationId: session.conversationId });
+    expect(mockSdk.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('negotiation needed and not supported'),
+      { conversationId: session.conversationId, sessionId: session.id }
+    );
   });
 });
 


### PR DESCRIPTION
Fixed the issue with switching system default audio device in chrome because chrome will only switch if there are no active tracks for the old system default mic. Added better logging around devices and switching