### PR TITLE
PCM-1794 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v7.0.0...HEAD)
 
+### Added
+* [PCM-1794](https://inindca.atlassian.net/browse/PCM-1794) – added `sdk.media.on('gumRequest' evt)` to notify consumers when the SDK makes a request to the
+  `widow.navigator.mediaDevices.getUserMedia()` API. This helps consumers to react appropriately to handle browsers that will only fulfil `gUM()` requests
+  if the window is in focus.
 # [v7.0.0](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v6.1.7...v7.0.0)
 ### BREAKING CHANGE
 * If you are providing a *logger*:

--- a/doc/media.md
+++ b/doc/media.md
@@ -577,7 +577,6 @@ For example, when calling through to
  2. for `hasMicPermissions` changing to `true` or `false`
   depending on the outcome of the `getUserMedia()` request
 
-
 > Note: in some browsers, permissions are not always guaranteed even after
 using [requestMediaPermissions()](#requestmediapermissions) to gain permissions. See [Firefox Behavior] for more details.
 It is recommended to use this event to watch for changes
@@ -590,6 +589,48 @@ sdk.media.on('permissions', (state: SdkMediaStateWithType) => { /* evt.eventType
 
 Value of event:
 * See [SdkMediaStateWithType]
+
+#### `gumRequest`
+Event when the SDK makes a request to `navigator.mediaDevices.getUserMedia()`
+(gUM). Many browsers only allow requests to `gUM()` when the window is in
+focus. Use this event to monitor when media is requested to ensure that the
+window is in focus so the media request will complete.
+
+> Note: if requesting both media types at the same time (`audio & video`), the
+  SDK will make _two_ separate `gUM()` requests – one for each media type
+  (see notes on `sdk.media.startMedia()`). This event will emit for _each_
+  `gUM()` request. For this reason, it is recommended to utilize the
+  `uuid` field of the `interface` [IMediaRequestOptions] to help track which
+  `gUM()` requests were made by your application (see docs for `IMediaRequestOptions#uuid`).
+
+Declaration:
+``` ts
+sdk.media.on('gumRequest', (request: ISdkGumRequest) => { });
+```
+
+Value of event:
+``` ts
+interface ISdkGumRequest {
+  /**
+   * The returned promise from the browser's
+   *  `getUserMedia()` (gUM) request
+   */
+  gumPromise: Promise<MediaStream>;
+
+  /**
+   * The requested options passed to the SDK
+   */
+  mediaRequestOptions: IMediaRequestOptions;
+
+  /**
+   * The actual media constraints used to make the
+   *  `getUserMedia()` (gUM) request.
+   */
+  constraints: MediaStreamConstraints;
+}
+```
+
+
 
 --------
 
@@ -667,6 +708,7 @@ interface IMediaRequestOptions {
   session?: IExtendedMediaSession;
   retryOnFailure?: boolean;
   preserveMediaIfOneTypeFails?: boolean;
+  uuid?: string | number;
 }
 ```
 * `audio?: string | boolean | null` – Optional: value for how to request audio media
@@ -705,6 +747,11 @@ interface IMediaRequestOptions {
       2. If using this flag, you may need to verify what tracks are received on the returned stream because it is not guaranteed
         that the stream will contain both types of media.
       3. If _both_ types of media fail, the error for the audio stream request will be thrown.
+* `uuid?: string | number;` – Optional: Option to pass in a uniqueID to be able to tie the media request
+   with the actual getUserMedia (gUM) request made to the browser.
+   See notes on the `sdk.media.on('gumRequest', evt)` event.
+   * Note: if no uuid is passed in the SDK will create one and use it for the request.
+
 #### IUpdateOutgoingMedia
 Interface for available options when requesting to update outgoing media.
 ``` ts

--- a/test/test-pages/common/sdk-controller.js
+++ b/test/test-pages/common/sdk-controller.js
@@ -107,6 +107,7 @@ function connectEventHandlers () {
   /* media related */
   webrtcSdk.media.on('audioTrackVolume', handleAudioChange);
   webrtcSdk.media.on('state', handleMediaStateChanges);
+  webrtcSdk.media.on('gumRequest', handleGumRequest);
 }
 
 function requestMicPermissions () {
@@ -149,6 +150,10 @@ function getCurrentMediaState () {
     addOptions('video-devices', state.videoDevices);
     addOptions('output-devices', state.outputDevices, true);
   }
+}
+
+function handleGumRequest (request) {
+  console.log('gumRequest', request);
 }
 
 function handleMediaStateChanges (state) {

--- a/test/unit/media/media.test.ts
+++ b/test/unit/media/media.test.ts
@@ -44,7 +44,6 @@ let navigatorMediaDevicesMock: {
 };
 
 describe('SdkMedia', () => {
-
   beforeEach(() => {
     jest.clearAllMocks();
     sdk = new SimpleMockSdk() as any;
@@ -215,7 +214,7 @@ describe('SdkMedia', () => {
       /* reset the media state */
       sdkMedia['setPermissions']({ micPermissionsRequested: false, cameraPermissionsRequested: false });
       const expectedLogDetails = {
-        mediaReqOptions: { video: true, audio: true, session: undefined, retryOnFailure: true },
+        mediaReqOptions: { video: true, audio: true, session: false, retryOnFailure: true, uuid: expect.any(String) },
         retryOnFailure: true,
         conversationId: undefined,
         sessionId: undefined,
@@ -233,6 +232,7 @@ describe('SdkMedia', () => {
 
       expect(sdk.logger.info).toHaveBeenCalledWith('calling sdk.media.startMedia()', {
         ...expectedLogDetails,
+        mediaReqOptions: { ...expectedLogDetails.mediaReqOptions, session: true },
         sessionId: session.id,
         conversationId: session.conversationId
       });
@@ -242,6 +242,7 @@ describe('SdkMedia', () => {
       /* reset the media state */
       sdkMedia['setPermissions']({ micPermissionsRequested: false, cameraPermissionsRequested: false });
       const requestOptions: IMediaRequestOptions = { audio: true, video: true };
+      const expectedReqOptions = { ...requestOptions, retryOnFailure: true, uuid: expect.any(String) };
 
       /* setup our mocks */
       const mockAudioStream = new MockStream({ audio: true });
@@ -252,8 +253,8 @@ describe('SdkMedia', () => {
 
       const stream = await sdkMedia.startMedia(requestOptions);
 
-      expect(requestMediaPermissionsSpy).toHaveBeenNthCalledWith(1, 'audio', true, requestOptions);
-      expect(requestMediaPermissionsSpy).toHaveBeenNthCalledWith(2, 'video', true, requestOptions);
+      expect(requestMediaPermissionsSpy).toHaveBeenNthCalledWith(1, 'audio', true, expectedReqOptions);
+      expect(requestMediaPermissionsSpy).toHaveBeenNthCalledWith(2, 'video', true, expectedReqOptions);
       expect(startSingleMediaSpy).not.toHaveBeenCalled();
       expect(stream.getTracks()).toEqual([
         mockAudioStream.getTracks()[0],
@@ -264,7 +265,7 @@ describe('SdkMedia', () => {
     it('should startSingleMedia for `audio` & `video` if already requested permissions', async () => {
       /* reset the media state */
       sdkMedia['setPermissions']({ micPermissionsRequested: true, cameraPermissionsRequested: true });
-      const requestOptions: IMediaRequestOptions = { audio: null, video: null, retryOnFailure: false };
+      const requestOptions: IMediaRequestOptions = { audio: null, video: null, retryOnFailure: false, uuid: 'kitty-hawk' };
 
       /* setup our mocks */
       const mockAudioStream = new MockStream({ audio: true });
@@ -287,7 +288,7 @@ describe('SdkMedia', () => {
     it('should only request audio and return the stream', async () => {
       /* reset the media state */
       sdkMedia['setPermissions']({ micPermissionsRequested: true, cameraPermissionsRequested: true });
-      const requestOptions: IMediaRequestOptions = { audio: true, video: false };
+      const requestOptions: IMediaRequestOptions = { audio: true, video: false, uuid: 'something-unique', retryOnFailure: true };
 
       /* setup our mocks */
       const mockAudioStream = new MockStream({ audio: true });
@@ -306,7 +307,7 @@ describe('SdkMedia', () => {
     it('should only request video and return the stream', async () => {
       /* reset the media state */
       sdkMedia['setPermissions']({ micPermissionsRequested: true, cameraPermissionsRequested: true });
-      const requestOptions: IMediaRequestOptions = { audio: false, video: true };
+      const requestOptions: IMediaRequestOptions = { audio: false, video: true, uuid: 'something-unique', retryOnFailure: false };
 
       /* setup our mocks */
       const mockVideoStream = new MockStream({ video: true });
@@ -325,7 +326,7 @@ describe('SdkMedia', () => {
     it('should throw an error after `video` is requested if `audio` failed and both media types were requested', async () => {
       /* reset the media state */
       sdkMedia['setPermissions']({ micPermissionsRequested: true, cameraPermissionsRequested: true });
-      const requestOptions: IMediaRequestOptions = { audio: null, video: null };
+      const requestOptions: IMediaRequestOptions = { audio: null, video: null, uuid: 'something-hidden', retryOnFailure: true };
       const error = new Error('Permission Denied');
 
       /* setup our mocks */
@@ -398,7 +399,7 @@ describe('SdkMedia', () => {
         await sdkMedia.startMedia(requestOptions);
         fail('should have thrown');
       } catch (e) {
-        expect(startSingleMediaSpy).toHaveBeenCalledWith('none', { retryOnFailure: false });
+        expect(startSingleMediaSpy).toHaveBeenCalledWith('none', { retryOnFailure: false, uuid: expect.any(String) });
         expect(e).toBe(error);
       }
     });
@@ -465,6 +466,7 @@ describe('SdkMedia', () => {
           video: false,
           session: undefined,
           retryOnFailure: true,
+          uuid: expect.any(String)
         },
         sessionId: undefined,
         conversationId: undefined,
@@ -489,7 +491,7 @@ describe('SdkMedia', () => {
 
       expect(enumerateDevicesSpy).toHaveBeenCalledTimes(2);
       expect(startSingleMediaSpy).toHaveBeenCalledTimes(1);
-      expect(startSingleMediaSpy).toHaveBeenNthCalledWith(1, 'audio', { audio: true, video: false, retryOnFailure: true });
+      expect(startSingleMediaSpy).toHaveBeenNthCalledWith(1, 'audio', { audio: true, video: false, retryOnFailure: true, uuid: expect.any(String) });
     });
 
     it('should always request the desired media type and never with the opposite media type', async () => {
@@ -497,58 +499,58 @@ describe('SdkMedia', () => {
       /* if `false` */
       let reqOptions: IMediaRequestOptions = { audio: false, video: true };
       await sdkMedia.requestMediaPermissions('audio', false, reqOptions);
-      expect(startSingleMediaSpy).toHaveBeenCalledWith('audio', { audio: true, video: false, retryOnFailure: true });
+      expect(startSingleMediaSpy).toHaveBeenCalledWith('audio', { audio: true, video: false, retryOnFailure: true, uuid: expect.any(String) });
 
       /* if `undefined` */
       reqOptions.audio = undefined;
       await sdkMedia.requestMediaPermissions('audio', false, reqOptions);
-      expect(startSingleMediaSpy).toHaveBeenCalledWith('audio', { audio: true, video: false, retryOnFailure: true });
+      expect(startSingleMediaSpy).toHaveBeenCalledWith('audio', { audio: true, video: false, retryOnFailure: true, uuid: expect.any(String) });
 
       /* if with deviceId */
       reqOptions.audio = 'deviceId';
       await sdkMedia.requestMediaPermissions('audio', false, reqOptions);
-      expect(startSingleMediaSpy).toHaveBeenCalledWith('audio', { audio: reqOptions.audio, video: false, retryOnFailure: true });
+      expect(startSingleMediaSpy).toHaveBeenCalledWith('audio', { audio: reqOptions.audio, video: false, retryOnFailure: true, uuid: expect.any(String) });
 
       /* VIDEO */
       /* if `false` */
       reqOptions = { video: false, audio: true };
       await sdkMedia.requestMediaPermissions('video', false, reqOptions);
-      expect(startSingleMediaSpy).toHaveBeenCalledWith('video', { video: true, audio: false, retryOnFailure: true });
+      expect(startSingleMediaSpy).toHaveBeenCalledWith('video', { video: true, audio: false, retryOnFailure: true, uuid: expect.any(String) });
 
       /* if `undefined` */
       reqOptions.video = undefined;
       await sdkMedia.requestMediaPermissions('video', false, reqOptions);
-      expect(startSingleMediaSpy).toHaveBeenCalledWith('video', { video: true, audio: false, retryOnFailure: true });
+      expect(startSingleMediaSpy).toHaveBeenCalledWith('video', { video: true, audio: false, retryOnFailure: true, uuid: expect.any(String) });
 
       /* if with deviceId */
       reqOptions.video = 'deviceId';
       await sdkMedia.requestMediaPermissions('video', false, reqOptions);
-      expect(startSingleMediaSpy).toHaveBeenCalledWith('video', { video: reqOptions.video, audio: false, retryOnFailure: true });
+      expect(startSingleMediaSpy).toHaveBeenCalledWith('video', { video: reqOptions.video, audio: false, retryOnFailure: true, uuid: expect.any(String) });
     });
 
     it('should always request both media types if `both` was requested', async () => {
       /* if `false` */
       const reqOptions: IMediaRequestOptions = { audio: false, video: false };
       await sdkMedia.requestMediaPermissions('both', false, reqOptions);
-      expect(startMediaSpy).toHaveBeenCalledWith({ audio: true, video: true, retryOnFailure: true });
+      expect(startMediaSpy).toHaveBeenCalledWith({ audio: true, video: true, retryOnFailure: true, uuid: expect.any(String) });
 
       /* if `undefined` */
       reqOptions.audio = undefined;
       reqOptions.video = undefined;
       await sdkMedia.requestMediaPermissions('both', false, reqOptions);
-      expect(startMediaSpy).toHaveBeenCalledWith({ audio: true, video: true, retryOnFailure: true });
+      expect(startMediaSpy).toHaveBeenCalledWith({ audio: true, video: true, retryOnFailure: true, uuid: expect.any(String) });
 
       /* if with deviceId */
       reqOptions.audio = 'audio-deviceId';
       reqOptions.video = 'video-deviceId';
       await sdkMedia.requestMediaPermissions('both', false, reqOptions);
-      expect(startMediaSpy).toHaveBeenCalledWith({ audio: true, video: true, retryOnFailure: true });
+      expect(startMediaSpy).toHaveBeenCalledWith({ audio: true, video: true, retryOnFailure: true, uuid: expect.any(String) });
     });
 
     it('should use `retryOnFailure` option if passed in', async () => {
       let reqOptions: IMediaRequestOptions = { audio: true, video: false, retryOnFailure: false };
       await sdkMedia.requestMediaPermissions('audio', false, reqOptions);
-      expect(startSingleMediaSpy).toHaveBeenCalledWith('audio', { audio: true, video: false, retryOnFailure: false });
+      expect(startSingleMediaSpy).toHaveBeenCalledWith('audio', { audio: true, video: false, retryOnFailure: false, uuid: expect.any(String) });
     });
 
     it('should return the media if `preserveMedia` was `true`', async () => {


### PR DESCRIPTION
added media 'gumRequest' event for eventing when the sdk is request gUM.

This shouldn't merge until we release v7. Unless we really want this in v7. But we would need a new CM. 

Also, this should be a **minor** version bump when it is prepped. 