### PR TITLE
PCM-1797

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,15 @@ webappPipeline {
         readJSON(file: 'dist/manifest.json')
     }
 
+    deployConfig = [
+      dev : 'always',
+      test : 'always',
+      prod : 'always',
+      'fedramp-use2-core': 'always'
+    ]
+
+    autoSubmitCm = true
+
     testJob = 'no-tests' // see buildStep to spigot tests
 
     ciTests = {
@@ -91,13 +100,6 @@ VERSION      : ${env.VERSION}
           hasRunSpigotTests = true // have to use this because it builds twice (once for legacy build)
         }
     }
-
-    deployConfig = [
-      dev : 'always',
-      test : 'always',
-      prod : 'always',
-      'fedramp-use2-core': 'always'
-    ]
 
     onSuccess = {
        sh("""

--- a/src/client.ts
+++ b/src/client.ts
@@ -140,6 +140,7 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
         /* sdk defaults */
         defaults: {
           ...defaultsOptions,
+          audioStream: undefined, // we set this below (with tracking)
           micAutoGainControl: defaultConfigOption(defaultsOptions.micAutoGainControl, true),
           micEchoCancellation: defaultConfigOption(defaultsOptions.micEchoCancellation, true),
           micNoiseSuppression: defaultConfigOption(defaultsOptions.micNoiseSuppression, true),
@@ -159,7 +160,7 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
     this._config.logger = this.logger;
 
     this.media = new SdkMedia(this);
-    this.setDefaultAudioStream(this._config.defaults.audioStream);
+    this.setDefaultAudioStream(defaultsOptions.audioStream);
 
     // Telemetry for specific events
     // onPendingSession, onSession, onMediaStarted, onSessionTerminated logged in event handlers

--- a/src/media/media.ts
+++ b/src/media/media.ts
@@ -460,14 +460,17 @@ export class SdkMedia extends (EventEmitter as { new(): StrictEventEmitter<Event
    * @param stream media stream to use
    */
   setDefaultAudioStream (stream?: MediaStream): void {
-    /* if we are nulling our the default */
-    if (!stream) {
-      return this.removeDefaultAudioStreamAndListeners();
-    }
-
     /* if we aren't changing to a new stream, we don't need to setup listeners again */
     if (stream === this.sdk._config.defaults.audioStream) {
       return;
+    }
+
+    /* clean up any existing default streams */
+    this.removeDefaultAudioStreamAndListeners();
+
+    /* if we aren't setting to a new stream */
+    if (!stream) {
+       return;
     }
 
     this.setupDefaultMediaStreamListeners(stream);

--- a/test/unit/media/media.test.ts
+++ b/test/unit/media/media.test.ts
@@ -758,6 +758,7 @@ describe('SdkMedia', () => {
     });
 
     it('should remove existing stream if null was passed in', () => {
+      sdk._config.defaults.audioStream = new MockStream() as any;
       sdkMedia.setDefaultAudioStream();
       expect(removeDefaultAudioStreamAndListenersSpy).toHaveBeenCalled();
       expect(setupDefaultMediaStreamListenersSpy).not.toHaveBeenCalled();
@@ -780,7 +781,7 @@ describe('SdkMedia', () => {
 
       sdkMedia.setDefaultAudioStream(stream);
 
-      expect(removeDefaultAudioStreamAndListenersSpy).not.toHaveBeenCalled();
+      expect(removeDefaultAudioStreamAndListenersSpy).toHaveBeenCalled();
       expect(setupDefaultMediaStreamListenersSpy).toHaveBeenCalledWith(stream);
       expect(sdk._config.defaults.audioStream).toBe(stream);
     });


### PR DESCRIPTION
 fixed bug that was not tracking default audio passed in on construction.

## Issue
With the way I had it setup, we would set the `defaults.audioStream` on construction _without_ using the new tracking functions. 