### PR TITLE
no-jira fix demo app to update outgoing media for phone calls

### DIFF
--- a/test/test-pages/common/sdk-controller.js
+++ b/test/test-pages/common/sdk-controller.js
@@ -328,6 +328,7 @@ function renderPendingSessions () {
 function handleConversationUpdate (event) {
   console.debug('received `conversationUpdate` event', event);
   conversationUpdatesToRender.activeConversationId = event.activeConversationId;
+  currentConversationId = event.activeConversationId;
   event.current.forEach(convoEvt => {
     conversationUpdatesToRender.conversations[convoEvt.conversationId] = convoEvt;
   });


### PR DESCRIPTION
Trying to update outgoing media in the demo app during a softphone call was not passing in the conversationId. 