### PR TITLE
PCM-1896 added a useHeadsets opt out flag to config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,15 +5,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v7.2.2...HEAD)
 
+### Fixed
+* [PCM-1893](https://inindca.atlassian.net/browse/PCM-1893) – added `useHeadsets: boolean` config option to allow "opting out" of the headset functionality.
+  See [docs on constructing the SDK](doc/index.md#constructor) for more details.
+
 # [v7.2.2](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v7.2.1...v7.2.2)
 ### Fixed
-* [PCM-1887](https://inindca.atlassian.net/browse/PCM-1887) Fixed how we create fake pending sessions for when line appearance == 1. Missed reference during refactor.
+* [PCM-1887](https://inindca.atlassian.net/browse/PCM-1887) – Fixed how we create fake pending sessions for when line appearance == 1. Missed reference during refactor.
 
 # [v7.2.1](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v7.2.0...v7.2.1)
 
 ### Fixed
 * Worked on issue found in Volt when there wasn't a proper device found after changing default devices
-* [PCM-1878](https://inindca.atlassian.net/browse/PCM-1878) cleaned up logging for `sdk.acceptSession()` which was logging the HTML elements and media stream
+* [PCM-1878](https://inindca.atlassian.net/browse/PCM-1878) – cleaned up logging for `sdk.acceptSession()` which was logging the HTML elements and media stream
   causing an infinite loop with the client-logger.
 * Ran `npm audit fix` to update deps and resolve security vulnerabilities
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -131,6 +131,7 @@ interface ISdkConfig {
     logLevel?: LogLevels;
     logger?: ILogger;
     optOutOfTelemetry?: boolean;
+    useHeadsets?: boolean;
     originAppName?: string;
     originAppVersion?: string;
     originAppId?: string;
@@ -248,6 +249,16 @@ Optional: default `false`.
 Opt out of sending logs to the server. Logs are only sent to the server
 if the default [GenesysCloudClientLogger] is used. The default logger will
 send logs to the server unless this option is `true`
+
+#### `useHeadsets`
+`useHeadsets?: boolean;`
+Optional: default `true`.
+
+Opt out of initializing the headset functionality included in the SDK.
+ See the "Headset" documentation of the SDK for more details.
+
+> Note: if `false`, a no-op stub will be used at `sdk.headset` to eliminate
+>  the need to "null" type check `sdk.headset` before using in code.
 
 #### `originAppName`
 `originAppName?: string;`

--- a/src/client.ts
+++ b/src/client.ts
@@ -35,7 +35,7 @@ import { setupLogging } from './logging';
 import { SdkErrorTypes, SessionTypes } from './types/enums';
 import { SessionManager } from './sessions/session-manager';
 import { SdkMedia } from './media/media';
-import { ISdkHeadset, SdkHeadset, SdkHeadsetStub } from './media/headset';
+import { SdkHeadset, SdkHeadsetBase, SdkHeadsetStub } from './media/headset';
 import { Constants } from 'stanza';
 
 const ENVIRONMENTS = [
@@ -89,7 +89,7 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
   sessionManager: SessionManager;
   media: SdkMedia;
   station: IStation | null;
-  headset: ISdkHeadset;
+  headset: SdkHeadsetBase;
 
   _connected: boolean;
   _streamingConnection: StreamingClient;
@@ -163,7 +163,7 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
     this._config.logger = this.logger;
 
     this.media = new SdkMedia(this);
-    this.headset = this._config.useHeadsets ? new SdkHeadset(this) : new SdkHeadsetStub();
+    this.headset = this._config.useHeadsets ? new SdkHeadset(this) : new SdkHeadsetStub(this);
     this.setDefaultAudioStream(defaultsOptions.audioStream);
 
     // Telemetry for specific events

--- a/src/media/headset.ts
+++ b/src/media/headset.ts
@@ -1,149 +1,201 @@
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import HeadsetService, { ConsumedHeadsetEvents, VendorImplementation } from 'softphone-vendor-headsets';
+
 import GenesysCloudWebrtcSdk from '../client';
-import HeadsetService, { ConsumedHeadsetEvents, VendorImplementation} from 'softphone-vendor-headsets';
 
-export class SdkHeadset {
-    private sdk: GenesysCloudWebrtcSdk;
-    private headsetLibrary: HeadsetService;
-    headsetEvents$: Observable<ConsumedHeadsetEvents>;
+export interface ISdkHeadset {
+  headsetEvents$: Observable<ConsumedHeadsetEvents>;
 
-    constructor (sdk: GenesysCloudWebrtcSdk) {
-        this.sdk = sdk;
-        this.headsetLibrary = HeadsetService.getInstance({ logger: sdk.logger });
-        this.headsetEvents$ = this.headsetLibrary.headsetEvents$;
+  /**
+   * Gets the currently selected vendor implementation from the headset library
+   * @params none
+   * @returns VendorImplementation
+   */
+  get currentSelectedImplementation (): VendorImplementation;
+
+  /**
+   * Updates the selected device and implementation within the headset library
+   * @param newMicId ID associated with the newly selected device
+   * @returns void
+   */
+  updateAudioInputDevice (newMicId: string): void;
+
+  /**
+   * Determines if the retry button is necessary to be rendered
+   * @params none
+   * @returns boolean
+   */
+  showRetry (): boolean;
+
+  /**
+   * Attempts to reconnect to the selected vendor's SDK
+   * @param micLabel the label that matches the currently selected device
+   * @returns Promise<void>
+   */
+  retryConnection (micLabel: string): Promise<void>;
+
+  /**
+   * Calls the headset library's incomingCall function to signal to the device
+   * to flash the answer call button's light to show an incoming call
+   * @param callInfo an object containing the conversationId and possible
+   * contactName for the incoming call that will be accepted or rejected
+   * @param hasOtherActiveCalls boolean determining if there are other active calls
+   * @returns Promise<void>
+   */
+  setRinging (callInfo: { conversationId: string, contactName?: string }, hasOtherActiveCalls: boolean): Promise<void>;
+
+  /**
+   * Calls the headset library's outgoingCall function to signal to the device
+   * to switch on the answer call button's light to show an active call
+   * @param callInfo an object containing the conversationId and possible
+   * contactName for the call that is outgoing
+   * @returns Promise<void>
+   */
+  outgoingCall (callInfo: { conversationId: string, contactName: string }): Promise<void>;
+
+  /**
+   * Calls the headset library's endCall function to signal to the device
+   * to switch off the answer call button's light to show the active call has ended
+   * @param conversationId a string representing the conversation that needs to be ended
+   * @returns Promise<void>
+   */
+  endCurrentCall (conversationId: string): Promise<void>;
+
+  /**
+   * Calls the headset library's endAllCalls() function to signal the device
+   * to switch off the answer call button's light to show the active calls have all ended
+   * @returns Promise<void>
+   */
+  endAllCalls (): Promise<void>;
+
+  /**
+   * Calls the headset library's answerIncomingCall function to signal the device
+   * to switch on the answer call button's light to show the call is now active
+   * @param conversationId a string representing the incoming call that is being
+   * answered
+   * @returns Promise<void>
+   */
+  answerIncomingCall (conversationId: string): Promise<void>;
+
+  /**
+   * Calls the headset library's rejectIncomingCall function to signal the device
+   * to switch on the answer call button's light to show the call has been rejected
+   * @param conversationId a string representing the incoming call that is being
+   * rejected
+   * @returns Promise<void>
+   */
+  rejectIncomingCall (conversationId: string): Promise<void>;
+
+  /**
+   * Calls the headset library's setMute function to signal the device to switch on
+   * or off (depending on the value of the passed in param) the mute call button's
+   * light to show the call has been muted or unmuted respectively
+   * @param isMuted boolean to show if the call should be muted(true) or unmuted(false)
+   * @returns Promise<void>
+   */
+  setMute (isMuted: boolean): Promise<void>;
+
+  /**
+   * Calls the headset library's setHold function to signal the device to switch on
+   * or off (depending on the value of the passed in param, isHeld) the hold call button's
+   * light to show the call has been held or resumed respectively
+   * @param conversationId string representing the call that is to be held or resumed
+   * @param isHeld boolean to show if the call should be held(true) or resumed(false)
+   * @returns Promise<void>
+   */
+  setHold (conversationId: string, isHeld: boolean): Promise<void>;
+}
+
+export class SdkHeadset implements ISdkHeadset {
+  private sdk: GenesysCloudWebrtcSdk;
+  private headsetLibrary: HeadsetService;
+  headsetEvents$: Observable<ConsumedHeadsetEvents>;
+
+  get currentSelectedImplementation (): VendorImplementation {
+    return this.headsetLibrary.selectedImplementation;
+  }
+
+  constructor (sdk: GenesysCloudWebrtcSdk) {
+    this.sdk = sdk;
+    this.headsetLibrary = HeadsetService.getInstance({ logger: sdk.logger });
+    this.headsetEvents$ = this.headsetLibrary.headsetEvents$;
+  }
+
+  updateAudioInputDevice (newMicId: string): void {
+    const completeDeviceInfo = this.sdk.media.findCachedDeviceByIdAndKind(newMicId, 'audioinput');
+    this.headsetLibrary.activeMicChange(completeDeviceInfo?.label?.toLowerCase());
+  }
+
+  showRetry (): boolean {
+    const selectedImplementation = this.currentSelectedImplementation;
+    if (selectedImplementation?.disableRetry) {
+      return false;
     }
 
-    /**
-     * Updates the selected device and implementation within the headset library
-     * @param newMicId ID associated with the newly selected device
-     * @returns void
-     */
-    updateAudioInputDevice (newMicId: string): void {
-        const completeDeviceInfo = this.sdk.media.findCachedDeviceByIdAndKind(newMicId, 'audioinput');
-        this.headsetLibrary.activeMicChange(completeDeviceInfo?.label?.toLowerCase());
+    return !!selectedImplementation
+      && !selectedImplementation.isConnected
+      && !selectedImplementation.isConnecting;
+  }
+
+  async retryConnection (micLabel: string): Promise<void> {
+    return micLabel && this.headsetLibrary.retryConnection(micLabel);
+  }
+
+  setRinging (callInfo: { conversationId: string, contactName?: string }, hasOtherActiveCalls: boolean): Promise<void> {
+    return this.headsetLibrary.incomingCall(callInfo, hasOtherActiveCalls);
+  }
+
+  outgoingCall (callInfo: { conversationId: string, contactName: string }): Promise<void> {
+    return this.headsetLibrary.outgoingCall(callInfo);
+  }
+
+  async endCurrentCall (conversationId: string): Promise<void> {
+    if (conversationId) {
+      return this.headsetLibrary.endCall(conversationId);
     }
+  }
 
-    /**
-     * Gets the currently selected vendor implementation from the headset library
-     * @params none
-     * @returns VendorImplementation
-     */
-    get currentSelectedImplementation (): VendorImplementation {
-        return this.headsetLibrary.selectedImplementation;
-    }
+  endAllCalls (): Promise<void> {
+    return this.headsetLibrary.endAllCalls();
+  }
 
-    /**
-     * Determines if the retry button is necessary to be rendered
-     * @params none
-     * @returns boolean
-     */
-    showRetry (): boolean {
-        const selectedImplementation = this.currentSelectedImplementation;
-        if (selectedImplementation?.disableRetry) {
-            return false;
-        }
+  answerIncomingCall (conversationId: string): Promise<void> {
+    return this.headsetLibrary.answerCall(conversationId);
+  }
 
-        return !!selectedImplementation
-            && !selectedImplementation.isConnected
-            && !selectedImplementation.isConnecting;
-    }
+  rejectIncomingCall (conversationId: string): Promise<void> {
+    return this.headsetLibrary.rejectCall(conversationId);
+  }
 
-    /**
-     * Attempts to reconnect to the selected vendor's SDK
-     * @param micLabel the label that matches the currently selected device
-     * @returns Promise<void>
-     */
-    async retryConnection (micLabel: string): Promise<void> {
-        return micLabel && this.headsetLibrary.retryConnection(micLabel);
-    }
+  setMute (isMuted: boolean): Promise<void> {
+    return this.headsetLibrary.setMute(isMuted);
+  }
 
-    /**
-     * Calls the headset library's incomingCall function to signal to the device
-     * to flash the answer call button's light to show an incoming call
-     * @param callInfo an object containing the conversationId and possible
-     * contactName for the incoming call that will be accepted or rejected
-     * @param hasOtherActiveCalls boolean determining if there are other active calls
-     * @returns Promise<void>
-     */
-    setRinging (callInfo: { conversationId: string, contactName?: string }, hasOtherActiveCalls): Promise<void> {
-        return this.headsetLibrary.incomingCall(callInfo, hasOtherActiveCalls);
-    }
+  setHold (conversationId: string, isHeld: boolean): Promise<void> {
+    return this.headsetLibrary.setHold(conversationId, isHeld);
+  }
+}
 
-    /**
-     * Calls the headset library's outgoingCall function to signal to the device
-     * to switch on the answer call button's light to show an active call
-     * @param callInfo an object containing the conversationId and possible
-     * contactName for the call that is outgoing
-     * @returns Promise<void>
-     */
-    outgoingCall (callInfo: { conversationId: string, contactName: string }): Promise<void> {
-        return this.headsetLibrary.outgoingCall(callInfo);
-    }
+export class SdkHeadsetStub implements ISdkHeadset {
+  _fakeObservable: Subject<ConsumedHeadsetEvents>;
+  headsetEvents$: Observable<ConsumedHeadsetEvents>;
 
-    /**
-     * Calls the headset library's endCall function to signal to the device
-     * to switch off the answer call button's light to show the active call has ended
-     * @param conversationId a string representing the conversation that needs to be ended
-     * @returns Promise<void>
-     */
-    async endCurrentCall (conversationId: string): Promise<void> {
-        if (conversationId) {
-            return this.headsetLibrary.endCall(conversationId);
-        }
-    }
+  get currentSelectedImplementation (): VendorImplementation { return null; /* no-op */ }
 
-    /**
-     * Calls the headset library's endAllCalls() function to signal the device
-     * to switch off the answer call button's light to show the active calls have all ended
-     * @returns Promise<void>
-     */
-    endAllCalls (): Promise<void> {
-        return this.headsetLibrary.endAllCalls();
-    }
+  constructor () {
+    this._fakeObservable = new Subject();
+    this.headsetEvents$ = this._fakeObservable.asObservable();
+  }
 
-    /**
-     * Calls the headset library's answerIncomingCall function to signal the device
-     * to switch on the answer call button's light to show the call is now active
-     * @param conversationId a string representing the incoming call that is being
-     * answered
-     * @returns Promise<void>
-     */
-    answerIncomingCall (conversationId: string): Promise<void> {
-        return this.headsetLibrary.answerCall(conversationId);
-    }
-
-    /**
-     * Calls the headset library's rejectIncomingCall function to signal the device
-     * to switch on the answer call button's light to show the call has been rejected
-     * @param conversationId a string representing the incoming call that is being
-     * rejected
-     * @returns Promise<void>
-     */
-    rejectIncomingCall (conversationId: string): Promise<void> {
-        return this.headsetLibrary.rejectCall(conversationId);
-    }
-
-    /**
-     * Calls the headset library's setMute function to signal the device to switch on
-     * or off (depending on the value of the passed in param) the mute call button's
-     * light to show the call has been muted or unmuted respectively
-     * @param isMuted boolean to show if the call should be muted(true) or unmuted(false)
-     * @returns Promise<void>
-     */
-    setMute (isMuted: boolean): Promise<void> {
-        return this.headsetLibrary.setMute(isMuted);
-    }
-
-    /**
-     * Calls the headset library's setHold function to signal the device to switch on
-     * or off (depending on the value of the passed in param, isHeld) the hold call button's
-     * light to show the call has been held or resumed respectively
-     * @param conversationId string representing the call that is to be held or resumed
-     * @param isHeld boolean to show if the call should be held(true) or resumed(false)
-     * @returns Promise<void>
-     */
-    setHold (conversationId: string, isHeld: boolean): Promise<void> {
-        return this.headsetLibrary.setHold(conversationId, isHeld);
-    }
-
+  updateAudioInputDevice (_newMicId: string): void { /* no-op  */ }
+  showRetry (): boolean { return false; /* no-op */ }
+  async retryConnection (_micLabel: string): Promise<void> { /* no-op */ }
+  async setRinging (_callInfo: { conversationId: string, contactName?: string }, _hasOtherActiveCalls: boolean): Promise<void> { /* no-op */ }
+  async outgoingCall (_callInfo: { conversationId: string, contactName: string }): Promise<void> { /* no-op */ }
+  async endCurrentCall (_conversationId: string): Promise<void> { /* no-op */ }
+  async endAllCalls (): Promise<void> {/* no-op */ }
+  async answerIncomingCall (_conversationId: string): Promise<void> { /* no-op */ }
+  async rejectIncomingCall (_conversationId: string): Promise<void> { /* no-op */ }
+  async setMute (_isMuted: boolean): Promise<void> { /* no-op */ }
+  async setHold (_conversationId: string, _isHeld: boolean): Promise<void> { /* no-op */ }
 }

--- a/src/media/headset.ts
+++ b/src/media/headset.ts
@@ -3,7 +3,8 @@ import HeadsetService, { ConsumedHeadsetEvents, VendorImplementation } from 'sof
 
 import GenesysCloudWebrtcSdk from '../client';
 
-export interface ISdkHeadset {
+export abstract class SdkHeadsetBase {
+  protected sdk: GenesysCloudWebrtcSdk;
   headsetEvents$: Observable<ConsumedHeadsetEvents>;
 
   /**
@@ -11,28 +12,32 @@ export interface ISdkHeadset {
    * @params none
    * @returns VendorImplementation
    */
-  get currentSelectedImplementation (): VendorImplementation;
+  get currentSelectedImplementation (): VendorImplementation { return null; /* no-op */ }
+
+  constructor (sdk: GenesysCloudWebrtcSdk) {
+    this.sdk = sdk;
+  }
 
   /**
    * Updates the selected device and implementation within the headset library
    * @param newMicId ID associated with the newly selected device
    * @returns void
    */
-  updateAudioInputDevice (newMicId: string): void;
+  updateAudioInputDevice (_newMicId: string): void { /* no-op  */ }
 
   /**
    * Determines if the retry button is necessary to be rendered
    * @params none
    * @returns boolean
    */
-  showRetry (): boolean;
+  showRetry (): boolean { return false; /* no-op */ }
 
   /**
    * Attempts to reconnect to the selected vendor's SDK
    * @param micLabel the label that matches the currently selected device
    * @returns Promise<void>
    */
-  retryConnection (micLabel: string): Promise<void>;
+  async retryConnection (_micLabel: string): Promise<void> { /* no-op */ }
 
   /**
    * Calls the headset library's incomingCall function to signal to the device
@@ -42,7 +47,7 @@ export interface ISdkHeadset {
    * @param hasOtherActiveCalls boolean determining if there are other active calls
    * @returns Promise<void>
    */
-  setRinging (callInfo: { conversationId: string, contactName?: string }, hasOtherActiveCalls: boolean): Promise<void>;
+  async setRinging (_callInfo: { conversationId: string, contactName?: string }, _hasOtherActiveCalls: boolean): Promise<void> { /* no-op */ }
 
   /**
    * Calls the headset library's outgoingCall function to signal to the device
@@ -51,7 +56,7 @@ export interface ISdkHeadset {
    * contactName for the call that is outgoing
    * @returns Promise<void>
    */
-  outgoingCall (callInfo: { conversationId: string, contactName: string }): Promise<void>;
+  async outgoingCall (_callInfo: { conversationId: string, contactName: string }): Promise<void> { /* no-op */ }
 
   /**
    * Calls the headset library's endCall function to signal to the device
@@ -59,14 +64,14 @@ export interface ISdkHeadset {
    * @param conversationId a string representing the conversation that needs to be ended
    * @returns Promise<void>
    */
-  endCurrentCall (conversationId: string): Promise<void>;
+  async endCurrentCall (_conversationId: string): Promise<void> { /* no-op */ }
 
   /**
    * Calls the headset library's endAllCalls() function to signal the device
    * to switch off the answer call button's light to show the active calls have all ended
    * @returns Promise<void>
    */
-  endAllCalls (): Promise<void>;
+  async endAllCalls (): Promise<void> {/* no-op */ }
 
   /**
    * Calls the headset library's answerIncomingCall function to signal the device
@@ -75,7 +80,7 @@ export interface ISdkHeadset {
    * answered
    * @returns Promise<void>
    */
-  answerIncomingCall (conversationId: string): Promise<void>;
+  async answerIncomingCall (_conversationId: string): Promise<void> { /* no-op */ }
 
   /**
    * Calls the headset library's rejectIncomingCall function to signal the device
@@ -84,7 +89,7 @@ export interface ISdkHeadset {
    * rejected
    * @returns Promise<void>
    */
-  rejectIncomingCall (conversationId: string): Promise<void>;
+  async rejectIncomingCall (_conversationId: string): Promise<void> { /* no-op */ }
 
   /**
    * Calls the headset library's setMute function to signal the device to switch on
@@ -93,7 +98,7 @@ export interface ISdkHeadset {
    * @param isMuted boolean to show if the call should be muted(true) or unmuted(false)
    * @returns Promise<void>
    */
-  setMute (isMuted: boolean): Promise<void>;
+  async setMute (_isMuted: boolean): Promise<void> { /* no-op */ }
 
   /**
    * Calls the headset library's setHold function to signal the device to switch on
@@ -103,29 +108,43 @@ export interface ISdkHeadset {
    * @param isHeld boolean to show if the call should be held(true) or resumed(false)
    * @returns Promise<void>
    */
-  setHold (conversationId: string, isHeld: boolean): Promise<void>;
+  async setHold (_conversationId: string, _isHeld: boolean): Promise<void> { /* no-op */ }
 }
 
-export class SdkHeadset implements ISdkHeadset {
-  private sdk: GenesysCloudWebrtcSdk;
+export class SdkHeadset extends SdkHeadsetBase {
   private headsetLibrary: HeadsetService;
   headsetEvents$: Observable<ConsumedHeadsetEvents>;
 
-  get currentSelectedImplementation (): VendorImplementation {
-    return this.headsetLibrary.selectedImplementation;
-  }
-
   constructor (sdk: GenesysCloudWebrtcSdk) {
-    this.sdk = sdk;
+    super(sdk);
     this.headsetLibrary = HeadsetService.getInstance({ logger: sdk.logger });
     this.headsetEvents$ = this.headsetLibrary.headsetEvents$;
   }
 
+  /**
+   * Updates the selected device and implementation within the headset library
+   * @param newMicId ID associated with the newly selected device
+   * @returns void
+   */
   updateAudioInputDevice (newMicId: string): void {
     const completeDeviceInfo = this.sdk.media.findCachedDeviceByIdAndKind(newMicId, 'audioinput');
     this.headsetLibrary.activeMicChange(completeDeviceInfo?.label?.toLowerCase());
   }
 
+  /**
+   * Gets the currently selected vendor implementation from the headset library
+   * @params none
+   * @returns VendorImplementation
+   */
+  get currentSelectedImplementation (): VendorImplementation {
+    return this.headsetLibrary.selectedImplementation;
+  }
+
+  /**
+   * Determines if the retry button is necessary to be rendered
+   * @params none
+   * @returns boolean
+   */
   showRetry (): boolean {
     const selectedImplementation = this.currentSelectedImplementation;
     if (selectedImplementation?.disableRetry) {
@@ -137,65 +156,114 @@ export class SdkHeadset implements ISdkHeadset {
       && !selectedImplementation.isConnecting;
   }
 
+  /**
+   * Attempts to reconnect to the selected vendor's SDK
+   * @param micLabel the label that matches the currently selected device
+   * @returns Promise<void>
+   */
   async retryConnection (micLabel: string): Promise<void> {
     return micLabel && this.headsetLibrary.retryConnection(micLabel);
   }
 
-  setRinging (callInfo: { conversationId: string, contactName?: string }, hasOtherActiveCalls: boolean): Promise<void> {
+  /**
+   * Calls the headset library's incomingCall function to signal to the device
+   * to flash the answer call button's light to show an incoming call
+   * @param callInfo an object containing the conversationId and possible
+   * contactName for the incoming call that will be accepted or rejected
+   * @param hasOtherActiveCalls boolean determining if there are other active calls
+   * @returns Promise<void>
+   */
+  setRinging (callInfo: { conversationId: string, contactName?: string }, hasOtherActiveCalls): Promise<void> {
     return this.headsetLibrary.incomingCall(callInfo, hasOtherActiveCalls);
   }
 
+  /**
+   * Calls the headset library's outgoingCall function to signal to the device
+   * to switch on the answer call button's light to show an active call
+   * @param callInfo an object containing the conversationId and possible
+   * contactName for the call that is outgoing
+   * @returns Promise<void>
+   */
   outgoingCall (callInfo: { conversationId: string, contactName: string }): Promise<void> {
     return this.headsetLibrary.outgoingCall(callInfo);
   }
 
+  /**
+   * Calls the headset library's endCall function to signal to the device
+   * to switch off the answer call button's light to show the active call has ended
+   * @param conversationId a string representing the conversation that needs to be ended
+   * @returns Promise<void>
+   */
   async endCurrentCall (conversationId: string): Promise<void> {
     if (conversationId) {
       return this.headsetLibrary.endCall(conversationId);
     }
   }
 
+  /**
+   * Calls the headset library's endAllCalls() function to signal the device
+   * to switch off the answer call button's light to show the active calls have all ended
+   * @returns Promise<void>
+   */
   endAllCalls (): Promise<void> {
     return this.headsetLibrary.endAllCalls();
   }
 
+  /**
+   * Calls the headset library's answerIncomingCall function to signal the device
+   * to switch on the answer call button's light to show the call is now active
+   * @param conversationId a string representing the incoming call that is being
+   * answered
+   * @returns Promise<void>
+   */
   answerIncomingCall (conversationId: string): Promise<void> {
     return this.headsetLibrary.answerCall(conversationId);
   }
 
+  /**
+   * Calls the headset library's rejectIncomingCall function to signal the device
+   * to switch on the answer call button's light to show the call has been rejected
+   * @param conversationId a string representing the incoming call that is being
+   * rejected
+   * @returns Promise<void>
+   */
   rejectIncomingCall (conversationId: string): Promise<void> {
     return this.headsetLibrary.rejectCall(conversationId);
   }
 
+  /**
+   * Calls the headset library's setMute function to signal the device to switch on
+   * or off (depending on the value of the passed in param) the mute call button's
+   * light to show the call has been muted or unmuted respectively
+   * @param isMuted boolean to show if the call should be muted(true) or unmuted(false)
+   * @returns Promise<void>
+   */
   setMute (isMuted: boolean): Promise<void> {
     return this.headsetLibrary.setMute(isMuted);
   }
 
+  /**
+   * Calls the headset library's setHold function to signal the device to switch on
+   * or off (depending on the value of the passed in param, isHeld) the hold call button's
+   * light to show the call has been held or resumed respectively
+   * @param conversationId string representing the call that is to be held or resumed
+   * @param isHeld boolean to show if the call should be held(true) or resumed(false)
+   * @returns Promise<void>
+   */
   setHold (conversationId: string, isHeld: boolean): Promise<void> {
     return this.headsetLibrary.setHold(conversationId, isHeld);
   }
+
 }
 
-export class SdkHeadsetStub implements ISdkHeadset {
+
+export class SdkHeadsetStub extends SdkHeadsetBase {
   _fakeObservable: Subject<ConsumedHeadsetEvents>;
   headsetEvents$: Observable<ConsumedHeadsetEvents>;
 
-  get currentSelectedImplementation (): VendorImplementation { return null; /* no-op */ }
-
-  constructor () {
+  constructor (sdk: GenesysCloudWebrtcSdk) {
+    super(sdk);
     this._fakeObservable = new Subject();
     this.headsetEvents$ = this._fakeObservable.asObservable();
   }
-
-  updateAudioInputDevice (_newMicId: string): void { /* no-op  */ }
-  showRetry (): boolean { return false; /* no-op */ }
-  async retryConnection (_micLabel: string): Promise<void> { /* no-op */ }
-  async setRinging (_callInfo: { conversationId: string, contactName?: string }, _hasOtherActiveCalls: boolean): Promise<void> { /* no-op */ }
-  async outgoingCall (_callInfo: { conversationId: string, contactName: string }): Promise<void> { /* no-op */ }
-  async endCurrentCall (_conversationId: string): Promise<void> { /* no-op */ }
-  async endAllCalls (): Promise<void> {/* no-op */ }
-  async answerIncomingCall (_conversationId: string): Promise<void> { /* no-op */ }
-  async rejectIncomingCall (_conversationId: string): Promise<void> { /* no-op */ }
-  async setMute (_isMuted: boolean): Promise<void> { /* no-op */ }
-  async setHold (_conversationId: string, _isHeld: boolean): Promise<void> { /* no-op */ }
 }

--- a/src/sessions/video-session-handler.ts
+++ b/src/sessions/video-session-handler.ts
@@ -517,7 +517,17 @@ export default class VideoSessionHandler extends BaseSessionHandler {
 
     // if conversation is already muted, we wont get an update so dont wait for one
     if (replayMuteRequest) {
-      this.log('warn', 'Replaying audio mute request since the local state already matches the requested state', { conversationId: session.conversationId, sessionId: session.id, sessionType: session.sessionType });
+      this.log('warn', 'Replaying audio mute request since the local state already matches the requested state', {
+        conversationId: session.conversationId,
+        sessionId: session.id,
+        sessionType: session.sessionType,
+        params: {
+          conversationId: params.conversationId,
+          mute: params.mute,
+          fromHeadset: params.fromHeadset,
+          unmuteDeviceId: params.unmuteDeviceId
+        }
+      });
     }
 
     const userId = this.sdk._personDetails.id;

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -80,7 +80,7 @@ export interface ISdkConfig {
    *
    * Optional: default `false`.
    */
-   autoAcceptPendingScreenRecordingRequests?: boolean;
+  autoAcceptPendingScreenRecordingRequests?: boolean;
 
   /**
    * The identifier that will go into the full jid. The jid will be constructed as {usersBareJid}/{jidResource}
@@ -161,6 +161,17 @@ export interface ISdkConfig {
    * Optional: default `false`
    */
   optOutOfTelemetry?: boolean;
+
+  /**
+   * Opt out of initializing the headset functionality included in the SDK.
+   *  See the "Headset" documentation of the SDK for more details.
+   *
+   * Note: if `false`, a no-op stub will be used at `sdk.headset` to eliminate
+   *  the need to "null" type check `sdk.headset` before using in code.
+   *
+   * Optional: default `true`
+   */
+  useHeadsets?: boolean;
 
   /**
    * Allowed session types the sdk instance should handle.
@@ -834,7 +845,7 @@ export interface ScreenRecordingMetadata {
   trackId: string;
 
   /**
-   * The id associated with the monitor/screen you are recording. This can often be found at 
+   * The id associated with the monitor/screen you are recording. This can often be found at
    * `MediaStreamTrack.getSettings().deviceId`.
    */
   screenId: string;
@@ -845,8 +856,8 @@ export interface ScreenRecordingMetadata {
   originX: number;
 
   /**
-   * The bottom coordinatefor this screen. *NOTE: Windows and Mac sometimes switch where 
-   * they reference originY. This property is for playback purposes and a Y coordinate of 
+   * The bottom coordinatefor this screen. *NOTE: Windows and Mac sometimes switch where
+   * they reference originY. This property is for playback purposes and a Y coordinate of
    * 0 should always represent the bottom of the screen.
    */
   originY: number;

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../../src';
 import * as utils from '../../src/utils';
 import { RetryPromise } from 'genesys-cloud-streaming-client/dist/es/utils';
+import { SdkHeadset, SdkHeadsetStub } from '../../src/media/headset';
 
 jest.mock('../../src/sessions/session-manager');
 jest.mock('../../src/media/media');
@@ -135,6 +136,7 @@ describe('Client', () => {
       expect(sdk._config.environment).toBe('mypurecloud.com');
       expect(sdk._config.autoConnectSessions).toBe(true);
       expect(sdk.isGuest).toBe(false);
+      expect(sdk.headset instanceof SdkHeadset).toBe(true);
     });
 
     it('sets up options when provided and track default audioStream', () => {
@@ -172,6 +174,11 @@ describe('Client', () => {
       expect(sdk.logger.info).toHaveBeenCalledWith('cancelPendingSession', ids);
       expect(sdk.logger.info).toHaveBeenCalledWith('handledPendingSession', ids);
 
+    });
+
+    it('should use SdkHeadsetStub if opted out', () => {
+      const sdk = constructSdk({ accessToken: '1234', useHeadsets: false } as ISdkConfig);
+      expect(sdk.headset instanceof SdkHeadsetStub).toBe(true);
     });
   });
 
@@ -804,7 +811,7 @@ describe('Client', () => {
       expect(sdk._config.accessToken).toBe(newToken);
       expect(mockLogger.setAccessToken).toHaveBeenCalledWith(newToken);
       expect(sdk._streamingConnection).toBeFalsy();
-      
+
       // add streamingConnection
     });
   });

--- a/test/unit/media/headset.test.ts
+++ b/test/unit/media/headset.test.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import { SdkHeadset } from "../../../src/media/headset";
+import { SdkHeadset, SdkHeadsetStub } from '../../../src/media/headset';
 import GenesysCloudWebrtSdk from "../../../src";
 import HeadsetService, { ConsumedHeadsetEvents } from 'softphone-vendor-headsets';
 import { SimpleMockSdk } from '../../test-utils';
@@ -10,161 +10,241 @@ let headsetLibrary: HeadsetService;
 let headsetEvents$: Observable<ConsumedHeadsetEvents>;
 
 describe('SdkHeadset', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-        headsetLibrary = HeadsetService.getInstance({ logger: console });
-        headsetEvents$ = headsetLibrary.headsetEvents$;
-        sdk = new SimpleMockSdk() as any;
-        sdkHeadset = new SdkHeadset(sdk);
-    })
+  beforeEach(() => {
+    jest.clearAllMocks();
+    headsetLibrary = HeadsetService.getInstance({ logger: console });
+    headsetEvents$ = headsetLibrary.headsetEvents$;
+    sdk = new SimpleMockSdk() as any;
+    sdkHeadset = new SdkHeadset(sdk);
+  });
 
-    afterEach(() => {
-        jest.restoreAllMocks();
-    })
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-    describe('constructor()', () => {
-        it('should start initialization', () => {
-            // const headset = new SdkHeadset(sdkMedia);
-            expect(sdkHeadset['sdk']).toBe(sdk);
-            expect(sdkHeadset['headsetLibrary']).toBe(headsetLibrary);
-            expect(sdkHeadset['headsetEvents$']).toStrictEqual(headsetEvents$);
-        })
-    })
+  describe('constructor()', () => {
+    it('should start initialization', () => {
+      // const headset = new SdkHeadset(sdkMedia);
+      expect(sdkHeadset['sdk']).toBe(sdk);
+      expect(sdkHeadset['headsetLibrary']).toBe(headsetLibrary);
+      expect(sdkHeadset['headsetEvents$']).toStrictEqual(headsetEvents$);
+    });
+  });
 
-    describe('updateAudioInputDevice', () => {
-        it('should fetch the proper device and send it to the headset library', () => {
-            const testId = "testId";
-            const findCachedDeviceByIdAndKindSpy = jest.spyOn(sdk.media, 'findCachedDeviceByIdAndKind').mockReturnValue({
-                kind: 'audioinput',
-                deviceId: 'testId',
-                label: 'Test Device Mark V',
-            } as MediaDeviceInfo);
-            const activeMicChangeSpy = jest.spyOn(headsetLibrary, 'activeMicChange');
-            sdkHeadset.updateAudioInputDevice(testId);
-            expect(findCachedDeviceByIdAndKindSpy).toHaveBeenCalledWith(testId, 'audioinput');
-            expect(activeMicChangeSpy).toHaveBeenCalledWith('test device mark v');
-        })
-        it('should properly handle if NO device is returned from findCachedDeviceByIdAndKind', () => {
-            const testId = "testId";
-            const findCachedDeviceByIdAndKindSpy = jest.spyOn(sdk.media, 'findCachedDeviceByIdAndKind').mockReturnValueOnce(undefined)
-                .mockReturnValueOnce({} as MediaDeviceInfo);
-            const activeMicChangeSpy = jest.spyOn(headsetLibrary, 'activeMicChange');
-            sdkHeadset.updateAudioInputDevice(testId);
-            expect(findCachedDeviceByIdAndKindSpy).toHaveBeenCalledWith(testId, 'audioinput');
-            expect(activeMicChangeSpy).toHaveBeenCalledWith(undefined);
+  describe('updateAudioInputDevice', () => {
+    it('should fetch the proper device and send it to the headset library', () => {
+      const testId = "testId";
+      const findCachedDeviceByIdAndKindSpy = jest.spyOn(sdk.media, 'findCachedDeviceByIdAndKind').mockReturnValue({
+        kind: 'audioinput',
+        deviceId: 'testId',
+        label: 'Test Device Mark V',
+      } as MediaDeviceInfo);
+      const activeMicChangeSpy = jest.spyOn(headsetLibrary, 'activeMicChange');
+      sdkHeadset.updateAudioInputDevice(testId);
+      expect(findCachedDeviceByIdAndKindSpy).toHaveBeenCalledWith(testId, 'audioinput');
+      expect(activeMicChangeSpy).toHaveBeenCalledWith('test device mark v');
+    });
+    it('should properly handle if NO device is returned from findCachedDeviceByIdAndKind', () => {
+      const testId = "testId";
+      const findCachedDeviceByIdAndKindSpy = jest.spyOn(sdk.media, 'findCachedDeviceByIdAndKind').mockReturnValueOnce(undefined)
+        .mockReturnValueOnce({} as MediaDeviceInfo);
+      const activeMicChangeSpy = jest.spyOn(headsetLibrary, 'activeMicChange');
+      sdkHeadset.updateAudioInputDevice(testId);
+      expect(findCachedDeviceByIdAndKindSpy).toHaveBeenCalledWith(testId, 'audioinput');
+      expect(activeMicChangeSpy).toHaveBeenCalledWith(undefined);
 
-            sdkHeadset.updateAudioInputDevice(testId);
-            expect(activeMicChangeSpy).toHaveBeenCalledWith(undefined);
-        })
-    })
+      sdkHeadset.updateAudioInputDevice(testId);
+      expect(activeMicChangeSpy).toHaveBeenCalledWith(undefined);
+    });
+  });
 
-    describe('getCurrentSelectedImplementation()', () => {
-        it('should fetch the currently selected vendor implementation from the headset library', () => {
-            headsetLibrary.activeMicChange('plantronics test device');
-            expect(headsetLibrary.selectedImplementation).toStrictEqual(headsetLibrary['plantronics']);
-        })
-    })
+  describe('getCurrentSelectedImplementation()', () => {
+    it('should fetch the currently selected vendor implementation from the headset library', () => {
+      headsetLibrary.activeMicChange('plantronics test device');
+      expect(headsetLibrary.selectedImplementation).toStrictEqual(headsetLibrary['plantronics']);
+    });
+  });
 
-    describe('showRetry', () => {
-        it('should return false if the selected implementation has disableRetry as true', () => {
-            headsetLibrary.activeMicChange('plantronics test device');
-            headsetLibrary.selectedImplementation.disableRetry = true;
-            const showRetryResult = sdkHeadset.showRetry();
-            expect(showRetryResult).toBe(false);
-        })
+  describe('showRetry', () => {
+    it('should return false if the selected implementation has disableRetry as true', () => {
+      headsetLibrary.activeMicChange('plantronics test device');
+      headsetLibrary.selectedImplementation.disableRetry = true;
+      const showRetryResult = sdkHeadset.showRetry();
+      expect(showRetryResult).toBe(false);
+    });
 
-        it('should return true if disableRetry is false, isConnected is false and isConnecting is false', () => {
-            headsetLibrary.activeMicChange('plantronics test device');
-            headsetLibrary.selectedImplementation.disableRetry = false;
-            headsetLibrary.selectedImplementation.isConnecting = false;
-            const showRetryResult = sdkHeadset.showRetry();
-            expect(showRetryResult).toBe(true);
-        })
+    it('should return true if disableRetry is false, isConnected is false and isConnecting is false', () => {
+      headsetLibrary.activeMicChange('plantronics test device');
+      headsetLibrary.selectedImplementation.disableRetry = false;
+      headsetLibrary.selectedImplementation.isConnecting = false;
+      const showRetryResult = sdkHeadset.showRetry();
+      expect(showRetryResult).toBe(true);
+    });
 
-        it('should return false if disableRetry is false, isConnected is false but isConnecting is true', () => {
-            headsetLibrary.activeMicChange('plantronics test device');
-            headsetLibrary.selectedImplementation.isConnecting = true;
-            const showRetryResult = sdkHeadset.showRetry();
-            expect(showRetryResult).toBe(false);
-        })
+    it('should return false if disableRetry is false, isConnected is false but isConnecting is true', () => {
+      headsetLibrary.activeMicChange('plantronics test device');
+      headsetLibrary.selectedImplementation.isConnecting = true;
+      const showRetryResult = sdkHeadset.showRetry();
+      expect(showRetryResult).toBe(false);
+    });
 
-        it('should return false if disableRetry is false, isConnecting is false but isConnected is true', () => {
-            headsetLibrary.activeMicChange('plantronics test device');
-            headsetLibrary.selectedImplementation.isConnected = true;
-            const showRetryResult = sdkHeadset.showRetry();
-            expect(showRetryResult).toBe(false);
-        })
+    it('should return false if disableRetry is false, isConnecting is false but isConnected is true', () => {
+      headsetLibrary.activeMicChange('plantronics test device');
+      headsetLibrary.selectedImplementation.isConnected = true;
+      const showRetryResult = sdkHeadset.showRetry();
+      expect(showRetryResult).toBe(false);
+    });
 
-        it('should return false if the selectedImplementation is falsy', () => {
-            headsetLibrary.selectedImplementation = undefined;
-            const showRetryResult = sdkHeadset.showRetry();
-            expect(showRetryResult).toBe(false);
-        })
-    })
+    it('should return false if the selectedImplementation is falsy', () => {
+      headsetLibrary.selectedImplementation = undefined;
+      const showRetryResult = sdkHeadset.showRetry();
+      expect(showRetryResult).toBe(false);
+    });
+  });
 
-    describe('retryConnection', () => {
-        it('should properly call the connect function for the corresponding implementation', () => {
-            headsetLibrary.activeMicChange('plantronics test device');
-            const headsetConnectSpy = jest.spyOn(headsetLibrary['plantronics'], 'connect');
-            const headsetRetryConnectionSpy = jest.spyOn(headsetLibrary, 'retryConnection');
-            sdkHeadset.retryConnection('plantronics test device');
-            expect(headsetRetryConnectionSpy).toHaveBeenCalledWith('plantronics test device');
-            expect(headsetConnectSpy).toHaveBeenCalledWith('plantronics test device');
-        })
-    })
+  describe('retryConnection', () => {
+    it('should properly call the connect function for the corresponding implementation', () => {
+      headsetLibrary.activeMicChange('plantronics test device');
+      const headsetConnectSpy = jest.spyOn(headsetLibrary['plantronics'], 'connect');
+      const headsetRetryConnectionSpy = jest.spyOn(headsetLibrary, 'retryConnection');
+      sdkHeadset.retryConnection('plantronics test device');
+      expect(headsetRetryConnectionSpy).toHaveBeenCalledWith('plantronics test device');
+      expect(headsetConnectSpy).toHaveBeenCalledWith('plantronics test device');
+    });
+  });
 
-    describe('setRinging', () => {
-        it('should call the proper function in the headset library', () => {
-            const incomingCallSpy = jest.spyOn(headsetLibrary, 'incomingCall');
-            sdkHeadset.setRinging({conversationId: '123', contactName: 'Maxwell'}, false);
-            expect(incomingCallSpy).toHaveBeenCalledWith({conversationId: '123', contactName: 'Maxwell'}, false);
-        })
-    })
+  describe('setRinging', () => {
+    it('should call the proper function in the headset library', () => {
+      const incomingCallSpy = jest.spyOn(headsetLibrary, 'incomingCall');
+      sdkHeadset.setRinging({ conversationId: '123', contactName: 'Maxwell' }, false);
+      expect(incomingCallSpy).toHaveBeenCalledWith({ conversationId: '123', contactName: 'Maxwell' }, false);
+    });
+  });
 
-    describe('outgoingCall', () => {
-        it('should call the proper function in the headset library', () => {
-            const outgoingCallSpy = jest.spyOn(headsetLibrary, 'outgoingCall');
-            sdkHeadset.outgoingCall({conversationId: '123', contactName: 'Maxwell'});
-            expect(outgoingCallSpy).toHaveBeenCalledWith({conversationId: '123', contactName: 'Maxwell'});
-        })
-    })
+  describe('outgoingCall', () => {
+    it('should call the proper function in the headset library', () => {
+      const outgoingCallSpy = jest.spyOn(headsetLibrary, 'outgoingCall');
+      sdkHeadset.outgoingCall({ conversationId: '123', contactName: 'Maxwell' });
+      expect(outgoingCallSpy).toHaveBeenCalledWith({ conversationId: '123', contactName: 'Maxwell' });
+    });
+  });
 
-    describe('endCurrentCall', () => {
-        it('should call the proper function in the headset library', () => {
-            const endCurrentCallSpy = jest.spyOn(headsetLibrary, 'endCall');
-            sdkHeadset.endCurrentCall('');
-            expect(endCurrentCallSpy).not.toHaveBeenCalled();
+  describe('endCurrentCall', () => {
+    it('should call the proper function in the headset library', () => {
+      const endCurrentCallSpy = jest.spyOn(headsetLibrary, 'endCall');
+      sdkHeadset.endCurrentCall('');
+      expect(endCurrentCallSpy).not.toHaveBeenCalled();
 
-            sdkHeadset.endCurrentCall('123');
-            expect(endCurrentCallSpy).toHaveBeenCalledWith('123');
+      sdkHeadset.endCurrentCall('123');
+      expect(endCurrentCallSpy).toHaveBeenCalledWith('123');
 
-            const endAllCallsSpy = jest.spyOn(headsetLibrary, 'endAllCalls');
-            sdkHeadset.endAllCalls();
-            expect(endAllCallsSpy).toHaveBeenCalled();
-        })
-    })
+      const endAllCallsSpy = jest.spyOn(headsetLibrary, 'endAllCalls');
+      sdkHeadset.endAllCalls();
+      expect(endAllCallsSpy).toHaveBeenCalled();
+    });
+  });
 
-    describe('answerIncomingCall', () => {
-        it('should call the proper function in the headset library', () => {
-            const answerCallSpy = jest.spyOn(headsetLibrary, 'answerCall');
-            sdkHeadset.answerIncomingCall('123');
-            expect(answerCallSpy).toHaveBeenCalledWith('123');
-        })
-    })
+  describe('answerIncomingCall', () => {
+    it('should call the proper function in the headset library', () => {
+      const answerCallSpy = jest.spyOn(headsetLibrary, 'answerCall');
+      sdkHeadset.answerIncomingCall('123');
+      expect(answerCallSpy).toHaveBeenCalledWith('123');
+    });
+  });
 
-    describe('setMute', () => {
-        it('should call the proper function in the headset library', () => {
-            const setMuteSpy = jest.spyOn(headsetLibrary, 'setMute');
-            sdkHeadset.setMute(true);
-            expect(setMuteSpy).toHaveBeenCalledWith(true);
-        })
-    })
+  describe('setMute', () => {
+    it('should call the proper function in the headset library', () => {
+      const setMuteSpy = jest.spyOn(headsetLibrary, 'setMute');
+      sdkHeadset.setMute(true);
+      expect(setMuteSpy).toHaveBeenCalledWith(true);
+    });
+  });
 
-    describe('setHold', () => {
-        it('should call the proper function in the headset library', () => {
-            const setHoldSpy = jest.spyOn(headsetLibrary, 'setHold');
-            sdkHeadset.setHold('123', false);
-            expect(setHoldSpy).toHaveBeenCalledWith('123', false);
-        })
-    })
-})
+  describe('setHold', () => {
+    it('should call the proper function in the headset library', () => {
+      const setHoldSpy = jest.spyOn(headsetLibrary, 'setHold');
+      sdkHeadset.setHold('123', false);
+      expect(setHoldSpy).toHaveBeenCalledWith('123', false);
+    });
+  });
+});
+
+describe('SdkHeadsetStub', () => {
+  let headsetStub: SdkHeadsetStub;
+
+  beforeEach(() => {
+    headsetStub = new SdkHeadsetStub();
+  });
+
+  describe('get currentSelectedImplementation()', () => {
+    it('should return null', () => {
+      expect(headsetStub.currentSelectedImplementation).toBe(null);
+    });
+  });
+
+  describe('updateAudioInputDevice()', () => {
+    it('should return undefined', () => {
+      expect(headsetStub.updateAudioInputDevice('')).toBe(undefined);
+    });
+  });
+
+  describe('showRetry()', () => {
+    it('should return false', () => {
+      expect(headsetStub.showRetry()).toBe(false);
+    });
+  });
+
+  describe('retryConnection()', () => {
+    it('should return an empty promise', async () => {
+      expect(await headsetStub.retryConnection('')).toBe(undefined);
+    });
+  });
+
+  describe('setRinging()', () => {
+    it('should return an empty promise', async () => {
+      expect(await headsetStub.setRinging({ conversationId: '' }, false)).toBe(undefined);
+    });
+  });
+
+  describe('outgoingCall()', () => {
+    it('should return an empty promise', async () => {
+      expect(await headsetStub.outgoingCall({ conversationId: '', contactName: '' })).toBe(undefined);
+    });
+  });
+
+  describe('endCurrentCall()', () => {
+    it('should return an empty promise', async () => {
+      expect(await headsetStub.endCurrentCall('')).toBe(undefined);
+    });
+  });
+
+  describe('endAllCalls()', () => {
+    it('should return an empty promise', async () => {
+      expect(await headsetStub.endAllCalls()).toBe(undefined);
+    });
+  });
+
+  describe('answerIncomingCall()', () => {
+    it('should return an empty promise', async () => {
+      expect(await headsetStub.answerIncomingCall('')).toBe(undefined);
+    });
+  });
+
+  describe('rejectIncomingCall()', () => {
+    it('should return an empty promise', async () => {
+      expect(await headsetStub.rejectIncomingCall('')).toBe(undefined);
+    });
+  });
+
+  describe('setMute()', () => {
+    it('should return an empty promise', async () => {
+      expect(await headsetStub.setMute(false)).toBe(undefined);
+    });
+  });
+
+  describe('setHold()', () => {
+    it('should return an empty promise', async () => {
+      expect(await headsetStub.setHold('', false)).toBe(undefined);
+    });
+  });
+});

--- a/test/unit/media/headset.test.ts
+++ b/test/unit/media/headset.test.ts
@@ -173,7 +173,7 @@ describe('SdkHeadsetStub', () => {
   let headsetStub: SdkHeadsetStub;
 
   beforeEach(() => {
-    headsetStub = new SdkHeadsetStub();
+    headsetStub = new SdkHeadsetStub(sdk);
   });
 
   describe('get currentSelectedImplementation()', () => {


### PR DESCRIPTION
The simplest way I could think to do this without making it a breaking change was to just use a "stubbed" version of the `SdkHeadset` class. That way consumers don't have to null type check before using it. 