### PR TITLE
[PCM-2206] - Fixed bug preventing users from unholding a session on a multi-call after ending a call with LA>1 and PC.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v8.1.4...HEAD)
+### Fixed
+* [PCM-2206](https://inindca.atlassian.net/browse/PCM-2206) - fixed bug preventing users from unholding a session on a multi-call, after ending a call while LA=100 with persistent connection.
+
 # [v8.1.4](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v8.1.3...v8.1.4)
 ### Fixed
 * [PCM-2203](https://inindca.atlassian.net/browse/PCM-2203) - fixed issue when trying to place or receive calls after cpu wake when persistent connection was active before sleep

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -728,8 +728,8 @@ export default class SoftphoneSessionHandler extends BaseSessionHandler {
     });
 
     try {
-      // If we're unholding and LA > 1, we need to hold the other active sessions.
-      if (!params.held && this.sdk.isConcurrentSoftphoneSessionsEnabled()) {
+      // If we're unholding and LA > 1, we need to hold the other active sessions. If PC is on, we need to make sure there are other conversations.
+      if (!params.held && this.sdk.isConcurrentSoftphoneSessionsEnabled() && Object.keys(this.conversations).length > 1) {
         this.holdOtherSessions(session);
       }
 

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -2239,6 +2239,7 @@ describe('setConversationHeld()', () => {
     const params: IConversationHeldRequest = { conversationId, held: false };
     const holdOtherSessionsSpy = jest.spyOn(handler, 'holdOtherSessions').mockImplementation();
     jest.spyOn(mockSdk, 'isConcurrentSoftphoneSessionsEnabled').mockReturnValue(true);
+    handler.conversations = {'123': {}, '234': {} } as any;
 
     await handler.setConversationHeld(session, params);
 


### PR DESCRIPTION
Context: 
If a user was on a multi-call with LA100 and PC on, and then ended a call, they would not be able to unhold a session. This is because we automatically hold all other sessions when unholding with LA100. With persistent connection on, the session with the call they just ended would still exist, so when unholding, it would try to hold that session even though there's no active conversation on it, throwing an error and preventing you from unholding altogether. 