### PR TITLE
[STREAM-22] Unhandled error 'no elements in sequence' coming from rxjs in WebRTC SDK

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v9.1.0...HEAD)
+### Fixed
+* [STREAM-22](https://inindca.atlassian.net/browse/STREAM-22) - fix for unhandled exception thrown from RXJS `first` operator when there are no elements from the Observable
 
 # [v9.1.0](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v9.0.8...v9.1.0)
 ### Fixed

--- a/src/sessions/screen-recording-session-handler.ts
+++ b/src/sessions/screen-recording-session-handler.ts
@@ -63,6 +63,8 @@ export class ScreenRecordingSessionHandler extends BaseSessionHandler {
   }
 
   private sendMetadataWhenSessionConnects (session: ScreenRecordingMediaSession, metadatas: ScreenRecordingMetadata[]) {
+    // We really only want to ignore the error handling (because that should never execute), but putting an ignore closer to that line doesn't properly ignore it
+    /* istanbul ignore next */
     fromEvent(session.peerConnection, 'connectionstatechange')
       .pipe(
         takeWhile(() => {
@@ -78,8 +80,9 @@ export class ScreenRecordingSessionHandler extends BaseSessionHandler {
       });
   }
 
-  _logSubscriptionError(e: any) {
-    // This is simply so we can test for thrown exceptions with an RXJS subscription
+  /* istanbul ignore next */
+  _logSubscriptionError(e: unknown) {
+    // This is for testing thrown exceptions with an RXJS subscription
   }
 
   async endSession (conversationId: string, session: IExtendedMediaSession, reason?: Constants.JingleReasonCondition): Promise<void> {

--- a/test/unit/sessions/screen-recording-session-handler.test.ts
+++ b/test/unit/sessions/screen-recording-session-handler.test.ts
@@ -67,6 +67,24 @@ describe('sendMetadataWhenSessionConnects', () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it('should send metadata only the first time peer connection connects', async () => {
+    const pc = createFakePc();
+
+    const session = {
+      peerConnection: pc
+    };
+
+    const spy = handler['updateScreenRecordingMetadatas'] = jest.fn();
+
+    handler['sendMetadataWhenSessionConnects'](session as any, []);
+
+    pc.connectionState = 'connected';
+    pc.dispatchEvent(new Event('connectionstatechange'));
+    pc.dispatchEvent(new Event('connectionstatechange'));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
   it('should not if peer connection never connects', async () => {
     const pc = createFakePc();
 
@@ -92,6 +110,22 @@ describe('sendMetadataWhenSessionConnects', () => {
     pc.connectionState = 'connected';
     pc.dispatchEvent(new Event('connectionstatechange'));
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should not throw an exception if peer connection state never connects', async () => {
+    const pc = createFakePc();
+
+    const session = {
+      peerConnection: pc
+    };
+
+    const errorSpy = handler['_logSubscribeError'] = jest.fn();
+
+    handler['sendMetadataWhenSessionConnects'](session as any, []);
+
+    pc.connectionState = 'disconnected';
+    pc.dispatchEvent(new Event('connectionstatechange'));
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Apparently `first` will throw an `EmptyError` if the Observable completes and no elements exists: https://rxjs.dev/api/operators/first

Not the behavior I would have expected, but easy enough to replace with `filter` and `take(1)`.