### PR TITLE
[STREAM-15] Move to modern Jest timers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v9.1.2...HEAD)
+### Changed
+* [STREAM-15](https://inindca.atlassian.net/browse/STREAM-15) - Move to modern modern Jest timers by telling Jest to not fake `nextTick`
 
 # [v9.1.2](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v9.1.1...v9.1.2)
 ### Fixed

--- a/test/unit/headset/headset.test.ts
+++ b/test/unit/headset/headset.test.ts
@@ -496,7 +496,7 @@ describe('HeadsetProxyService', () => {
     }
 
     beforeEach(() => {
-      jest.useFakeTimers({ legacyFakeTimers: true });
+      jest.useFakeTimers({ doNotFake: ['nextTick'] });
       updateAudioSpy = proxyService.updateAudioInputDevice = jest.fn();
       broadcastSpy = proxyService['sdk']._streamingConnection.messenger.broadcastMessage as jest.Mock;
       proxyService['sdk']._config.useHeadsets = true;


### PR DESCRIPTION
The ticket has details and references to documentation, but this turned out to be easy after Zach updated Jest to v29.