### PR TITLE
bumped SVH which contains VBeT changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genesys-cloud-webrtc-sdk",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "genesys-cloud-webrtc-sdk",
-      "version": "9.3.1",
+      "version": "9.3.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "process-fast": "^1.0.0",
         "rxjs": "^7.8.1",
         "safe-json-stringify": "^1.2.0",
-        "softphone-vendor-headsets": "^2.5.2",
+        "softphone-vendor-headsets": "^2.5.3",
         "strict-event-emitter-types": "^2.0.0",
         "uuid": "^9.0.1"
       },
@@ -3838,6 +3838,12 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vbet/webhid-sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.4.0.tgz",
+      "integrity": "sha512-zpQQLk+if5mF+Fztn4JHWcKSUl68iHPtUBsDXa4uXSl6ctytY6oK4c0kzM/qHGUn/9WLUj8oAxGoN0z3Gy/lew==",
+      "license": "ISC"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -13073,11 +13079,13 @@
       }
     },
     "node_modules/softphone-vendor-headsets": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-2.5.2.tgz",
-      "integrity": "sha512-Hdj1qmmoJ8NtDtYa73/zar/jBUY/Qsxq5JQjYTRqVManMeBd7iTkG0nZwGJEWQ96x4XhE5aFS66KIoBoHy6qnA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-2.5.3.tgz",
+      "integrity": "sha512-o0hPJ5ebi7baxRPG/XEMdew2j1F+bQQ0qt/OMl5/AEZX8RAQbamimmbVoH67NsoM3iPnwUqYRR40A95ORvxxtA==",
+      "license": "MIT",
       "dependencies": {
         "@gnaudio/jabra-js": "^4.2.1",
+        "@vbet/webhid-sdk": "^1.4.0",
         "browserama": "^3.2.0",
         "fetch-jsonp": "^1.2.1",
         "rxjs": "^7.4.0",
@@ -17639,6 +17647,11 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "@vbet/webhid-sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.4.0.tgz",
+      "integrity": "sha512-zpQQLk+if5mF+Fztn4JHWcKSUl68iHPtUBsDXa4uXSl6ctytY6oK4c0kzM/qHGUn/9WLUj8oAxGoN0z3Gy/lew=="
     },
     "@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -24710,11 +24723,12 @@
       "dev": true
     },
     "softphone-vendor-headsets": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-2.5.2.tgz",
-      "integrity": "sha512-Hdj1qmmoJ8NtDtYa73/zar/jBUY/Qsxq5JQjYTRqVManMeBd7iTkG0nZwGJEWQ96x4XhE5aFS66KIoBoHy6qnA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-2.5.3.tgz",
+      "integrity": "sha512-o0hPJ5ebi7baxRPG/XEMdew2j1F+bQQ0qt/OMl5/AEZX8RAQbamimmbVoH67NsoM3iPnwUqYRR40A95ORvxxtA==",
       "requires": {
         "@gnaudio/jabra-js": "^4.2.1",
+        "@vbet/webhid-sdk": "^1.4.0",
         "browserama": "^3.2.0",
         "fetch-jsonp": "^1.2.1",
         "rxjs": "^7.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "process-fast": "^1.0.0",
         "rxjs": "^7.8.1",
         "safe-json-stringify": "^1.2.0",
-        "softphone-vendor-headsets": "^2.5.3",
+        "softphone-vendor-headsets": "^2.5.4",
         "strict-event-emitter-types": "^2.0.0",
         "uuid": "^9.0.1"
       },
@@ -13079,9 +13079,9 @@
       }
     },
     "node_modules/softphone-vendor-headsets": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-2.5.3.tgz",
-      "integrity": "sha512-o0hPJ5ebi7baxRPG/XEMdew2j1F+bQQ0qt/OMl5/AEZX8RAQbamimmbVoH67NsoM3iPnwUqYRR40A95ORvxxtA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-2.5.4.tgz",
+      "integrity": "sha512-csyceoRFk/ej9H4J9zP4xA4dvP6ue4+aDgB3JulGI7TOKYCw9cGyppZ5UQAj/722//Ja3ne+LTSXLzjjO0OTbg==",
       "license": "MIT",
       "dependencies": {
         "@gnaudio/jabra-js": "^4.2.1",
@@ -24723,9 +24723,9 @@
       "dev": true
     },
     "softphone-vendor-headsets": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-2.5.3.tgz",
-      "integrity": "sha512-o0hPJ5ebi7baxRPG/XEMdew2j1F+bQQ0qt/OMl5/AEZX8RAQbamimmbVoH67NsoM3iPnwUqYRR40A95ORvxxtA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-2.5.4.tgz",
+      "integrity": "sha512-csyceoRFk/ej9H4J9zP4xA4dvP6ue4+aDgB3JulGI7TOKYCw9cGyppZ5UQAj/722//Ja3ne+LTSXLzjjO0OTbg==",
       "requires": {
         "@gnaudio/jabra-js": "^4.2.1",
         "@vbet/webhid-sdk": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "process-fast": "^1.0.0",
     "rxjs": "^7.8.1",
     "safe-json-stringify": "^1.2.0",
-    "softphone-vendor-headsets": "^2.5.2",
+    "softphone-vendor-headsets": "^2.5.3",
     "strict-event-emitter-types": "^2.0.0",
     "uuid": "^9.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "process-fast": "^1.0.0",
     "rxjs": "^7.8.1",
     "safe-json-stringify": "^1.2.0",
-    "softphone-vendor-headsets": "^2.5.3",
+    "softphone-vendor-headsets": "^2.5.4",
     "strict-event-emitter-types": "^2.0.0",
     "uuid": "^9.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genesys-cloud-webrtc-sdk",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "description": "client for the interfacing with Genesys Cloud WebRTC",
   "repository": "https://github.com/mypurecloud/genesys-cloud-webrtc-sdk",
   "license": "MIT",


### PR DESCRIPTION
One of the devs for VBeT refactored their implementation by introducing their own SDK.  It removes a lot of the hardcoded values and expands their support umbrella for more devices.  It also cut their implementation down by about half the size.