### PR TITLE
STREAM-315 fixed object pathing that we pass to web-dir; put in extra guard to only pass up FAILED events

### DIFF
--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -61,8 +61,8 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
 
     this.log('debug', 'persistent connection event', event.eventBody);
 
-    if (event.eventBody.errorInfo) {
-      createAndEmitSdkError.call(this.sdk, SdkErrorTypes.call, event.eventBody.errorInfo.userMessage, event.eventBody.errorInfo);
+    if (event.eventBody.errorInfo && event.eventBody.persistentState === 'FAILED') {
+      createAndEmitSdkError.call(this.sdk, SdkErrorTypes.call, event.eventBody.errorInfo.userMessage, event.eventBody);
     }
   }
 


### PR DESCRIPTION
The original v10 change had us emitting an error with `event.eventBody.errorInfo`.  However once the error reaches web-dir it is looking for `sdkError.details.errorInfo` which would come up undefined, which caused necessary errors to not pop up.  So one change now emits the error with `event.eventBody` so that `...errorInfo` is properly defined and populated once it reaches web-dir

In addition to the above, we had some discussions with the Eager Persistent Connection folks and determined to only emit errors that were actual errors, so anything that had a `persistentState` of `FAILED`.  This will still give us the expected error but not any benign errors.