### PR TITLE
[STREAM-798] - Bump streaming-client to 19.3.0 to pick up fixes/changes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [STREAM-785](https://inindca.atlassian.net/browse/STREAM-785) - Added GitHub Actions for linting, testing, and building in an effort to make the build process more transparent and reliable.
 
 # Changed
+* [STREAM-798](https://inindca.atlassian.net/browse/STREAM-798) - Bump streaming-client to version 19.3.0 to pick up the following fixes/changes:
+  - [STREAM-154](https://inindca.atlassian.net/browse/STREAM-154) - Track StanzaMediaSessions so events can still be processed if streaming-client is disconnected and reconnected.
+  - [STREAM-155](https://inindca.atlassian.net/browse/STREAM-155) - Calling `disconnect` will now stop any in-progress connection attempts.
+  - [STREAM-85](https://inindca.atlassian.net/browse/STREAM-85) - Handle connection transfer (`v2.system.socket_closing`) message from Hawk signaling a reconnect is necessary
+  - [STREAM-653](https://inindca.atlassian.net/browse/STREAM-653) - Added fields to upgradeMediaPresence stanza definition.
 * [STREAM-626](https://inindca.atlassian.net/browse/STREAM-626) - Removed pipeline infra from open-source. Updated CODEOWNERS.
 * [STREAM-654](https://inindca.atlassian.net/browse/STREAM-654) - Changed logging for disableAutoAnswer to clarify that if the SDK has disableAutoAnswer, the consuming client should handle auto-answering calls.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "browserama": "^3.2.2",
         "core-js": "^3.37.1",
         "genesys-cloud-client-logger": "^4.2.13",
-        "genesys-cloud-streaming-client": "^19.2.2",
+        "genesys-cloud-streaming-client": "^19.3.0",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "process-fast": "^1.0.0",
@@ -63,7 +63,7 @@
         "pre-push": "^0.1.4",
         "purecloud-platform-client-v2": "^116.0.0",
         "rimraf": "^5.0.7",
-        "rollup": "^4.45.1",
+        "rollup": "^4.18.0",
         "rollup-plugin-polyfill-node": "^0.13.0",
         "stupid-server": "^0.2.5",
         "ts-jest": "^29.1.4",
@@ -8073,9 +8073,9 @@
       }
     },
     "node_modules/genesys-cloud-streaming-client": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/genesys-cloud-streaming-client/-/genesys-cloud-streaming-client-19.2.2.tgz",
-      "integrity": "sha512-Sq74DDCoDm9EKJb665PlkFw30rQsRD3hylUcDR0PNHYENZCmZxMNtqn8pjwsK6dKzRKPVryMlrvPIr3NKz4nIw==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/genesys-cloud-streaming-client/-/genesys-cloud-streaming-client-19.3.0.tgz",
+      "integrity": "sha512-AYlGfeHW2wwU/duG7qMbJOHBkXNqOu8tZJzwoj9bTSC8QJs1eqKw9xeQYLopH7dj7t3bsbTZmvkHOJnwBI2cIg==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.10.4",
         "axios": "^1.7.4",
@@ -21043,9 +21043,9 @@
       }
     },
     "genesys-cloud-streaming-client": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/genesys-cloud-streaming-client/-/genesys-cloud-streaming-client-19.2.2.tgz",
-      "integrity": "sha512-Sq74DDCoDm9EKJb665PlkFw30rQsRD3hylUcDR0PNHYENZCmZxMNtqn8pjwsK6dKzRKPVryMlrvPIr3NKz4nIw==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/genesys-cloud-streaming-client/-/genesys-cloud-streaming-client-19.3.0.tgz",
+      "integrity": "sha512-AYlGfeHW2wwU/duG7qMbJOHBkXNqOu8tZJzwoj9bTSC8QJs1eqKw9xeQYLopH7dj7t3bsbTZmvkHOJnwBI2cIg==",
       "requires": {
         "@babel/runtime-corejs3": "^7.10.4",
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "browserama": "^3.2.2",
     "core-js": "^3.37.1",
     "genesys-cloud-client-logger": "^4.2.13",
-    "genesys-cloud-streaming-client": "^19.2.2",
+    "genesys-cloud-streaming-client": "^19.3.0",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "process-fast": "^1.0.0",


### PR DESCRIPTION
* [STREAM-798](https://inindca.atlassian.net/browse/STREAM-798) - Bump streaming-client to version 19.3.0 to pick up the following fixes/changes:
  - [STREAM-154](https://inindca.atlassian.net/browse/STREAM-154) - Track StanzaMediaSessions so events can still be processed if streaming-client is disconnected and reconnected.
  - [STREAM-155](https://inindca.atlassian.net/browse/STREAM-155) - Calling `disconnect` will now stop any in-progress connection attempts.
  - [STREAM-85](https://inindca.atlassian.net/browse/STREAM-85) - Handle connection transfer (`v2.system.socket_closing`) message from Hawk signaling a reconnect is necessary
  - [STREAM-653](https://inindca.atlassian.net/browse/STREAM-653) - Added fields to upgradeMediaPresence stanza definition.

[STREAM-798]: https://inindca.atlassian.net/browse/STREAM-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STREAM-154]: https://inindca.atlassian.net/browse/STREAM-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STREAM-155]: https://inindca.atlassian.net/browse/STREAM-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STREAM-85]: https://inindca.atlassian.net/browse/STREAM-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STREAM-653]: https://inindca.atlassian.net/browse/STREAM-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ