### PR TITLE
[STREAM-905] - Fix issue where `sessionStarted` was not emitted for calls that re-use persistent connections after a media recovery has occurred.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v12.0.0...HEAD)
+### Fixed
+* [STREAM-905](https://inindca.atlassian.net/browse/STREAM-905) - Fix issue where `sessionStarted` was not emitted for calls that re-use persistent connections after a media recovery has occurred. Now initializing `_emittedSessionStarteds` for reinvites but only emitting if not a reinvite.
+
 * [STREAM-1123](https://inindca.atlassian.net/browse/STREAM-1123) - Only update necessary tracks when changing devices. Prevent virtual background from getting replaced
 
 ### Changed

--- a/src/sessions/base-session-handler.ts
+++ b/src/sessions/base-session-handler.ts
@@ -124,8 +124,8 @@ export default abstract class BaseSessionHandler {
 
     session.on('terminated', this.onSessionTerminated.bind(this, session));
 
+    session._emittedSessionStarteds = {[session.conversationId]: true};
     if (!session.reinvite) {
-      session._emittedSessionStarteds = {[session.conversationId]: true};
       this.sdk.emit('sessionStarted', session);
     }
   }

--- a/test/unit/sessions/base-session-handler.test.ts
+++ b/test/unit/sessions/base-session-handler.test.ts
@@ -583,6 +583,24 @@ describe('handleSessionInit', () => {
     expect(eventSpy).toHaveBeenCalled();
   });
 
+  it('should initialize _emittedSessionStarteds but not emit sessionStarted for reinvite sessions', async () => {
+    const session: any = new MockSession();
+    session.conversationId = 'convo123';
+    session.reinvite = true;
+
+    const pendingSession = createPendingSession();
+    jest.spyOn(mockSessionManager, 'getPendingSession').mockReturnValue(pendingSession);
+
+    const eventSpy = jest.fn();
+    mockSdk.on('sessionStarted', eventSpy);
+
+    await handler.handleSessionInit(session);
+
+    expect(mockSdk._streamingConnection.webrtcSessions.rtcSessionAccepted).toHaveBeenCalled();
+    expect(session._emittedSessionStarteds).toEqual({ 'convo123': true });
+    expect(eventSpy).not.toHaveBeenCalled();
+  });
+
   it('should set up terminated listener', async () => {
     const session: any = new MockSession();
     const pendingSession = createPendingSession();


### PR DESCRIPTION
Now initializing `_emittedSessionStarteds` for reinvites but only emitting if not a reinvite.

### MERGE CHECKLIST

- [x] Tests have been updated, added, or removed and the testing matrix has passed.
- [x] Documentation has been updated or added.
- [x] Changelog has been updated with ticket or issue number, link to the ticket, and a description of the changes.
- [x] Branch has been built in the BitBucket wrapper repository.
- [x] Pull request title is formatted as `[STREAM-<ticket number>] - <description of changes>` or `[<issue number>] - <description of changes>`.
- [ ] Release pull requests include someone from the PureScale team for approval.
  - [ ] Build release branch in wrapper repository and make sure it is tagged with `next` on npm.

