### PR TITLE
[STREAM-1285] Refactor `handlePropose` in SoftphoneSessionHandler

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * [STREAM-1211](https://inindca.atlassian.net/browse/STREAM-1178) - Update `axios` to `v1.13.5`.
+* [STREAM-1285](https://inindca.atlassian.net/browse/STREAM-1285) - Refactor `handlePropose` in SoftphoneSessionHandler for clarity and future changes. Update associated comments to better reflect implementation.
 
 # [v12.0.0](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v11.5.1...v12.0.0)
 ### Added

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -153,31 +153,29 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
 
     if (isPrivAnswerAuto) {
       this.log('info', 'received a propose with privAnswerMode=true', logInfo);
-    }
 
-    // if eagerPersistentConnectionEstablishment==='none' then we want to completely swallow the propose
-    const shouldIgnorePrivAnswerPropose = isPrivAnswerAuto && eagerConnectionEstablishmentMode === 'none';
-    if (shouldIgnorePrivAnswerPropose) {
-      this.log('info', 'eagerPersistentConnectionEstablishment is "none" so propose with privAnswerMode=true will be ignored', logInfo);
-      return;
-    }
-
-    const shouldAutoAnswerPrivately = isPrivAnswerAuto && eagerConnectionEstablishmentMode === 'auto';
-
-    // we want to emit the pendingSession event in all cases except when eagerConnectionEstablishmentMode === auto and this is a privAnswerMode call
-    if (!shouldAutoAnswerPrivately) {
-      await super.handlePropose(pendingSession);
-    } else {
-      return await this.proceedWithSession(pendingSession);
-    }
-
-    // calls will can be marked as auto-answer or priv-answer-mode: Auto, but never both
-    if (pendingSession.autoAnswer) {
-      if (this.sdk._config.disableAutoAnswer) {
-        // It is possible that the consuming client has its own logic for auto-answering calls (eg. web-dir).
-        this.log('info', 'received an autoAnswer tagged propose but the SDK was configured to not auto-answer, deferring to the consuming client.', logInfo);
+      if (eagerConnectionEstablishmentMode === 'none') {
+        // we want to completely swallow the propose
+        this.log('info', 'eagerPersistentConnectionEstablishment is "none" so propose with privAnswerMode=true will be ignored', logInfo);
+        return;
+      } else if (eagerConnectionEstablishmentMode === 'auto') {
+        // we don't need to emit a pendingSession event when we auto-answer
+        // eager persistent connections
+        return await this.proceedWithSession(pendingSession);
       } else {
-        await this.proceedWithSession(pendingSession);
+        await super.handlePropose(pendingSession);
+      }
+    } else {
+      await super.handlePropose(pendingSession);
+
+      // calls will can be marked as auto-answer or priv-answer-mode: Auto, but never both
+      if (pendingSession.autoAnswer) {
+        if (this.sdk._config.disableAutoAnswer) {
+          // It is possible that the consuming client has its own logic for auto-answering calls (e.g. web-dir).
+          this.log('info', 'received an autoAnswer tagged propose but the SDK was configured to not auto-answer, deferring to the consuming client.', logInfo);
+        } else {
+          await this.proceedWithSession(pendingSession);
+        }
       }
     }
   }

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -152,20 +152,19 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
     const logInfo = { sessionId: pendingSession?.id, conversationId: pendingSession.conversationId };
 
     if (isPrivAnswerAuto) {
-      this.log('info', 'received a propose with privAnswerMode=true', logInfo);
+      this.log('info', 'received a propose with privAnswerMode=Auto', logInfo);
 
       if (eagerConnectionEstablishmentMode === 'none') {
-        // we want to completely swallow the propose
-        this.log('info', 'eagerPersistentConnectionEstablishment is "none" so propose with privAnswerMode=true will be ignored', logInfo);
+        this.log('info', 'eagerPersistentConnectionEstablishment is "none" so propose with privAnswerMode=Auto will be ignored', logInfo);
         return;
       } else if (eagerConnectionEstablishmentMode === 'auto') {
-        // we don't need to emit a pendingSession event when we auto-answer
-        // eager persistent connections
+        // we don't need to emit a pendingSession event when we auto-answer eager persistent connections
         return await this.proceedWithSession(pendingSession);
       } else {
         await super.handlePropose(pendingSession);
       }
     } else {
+      // we want to emit the pendingSession event in all other cases
       await super.handlePropose(pendingSession);
 
       // calls will can be marked as auto-answer or priv-answer-mode: Auto, but never both

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -116,9 +116,7 @@ export interface ISdkFullConfig {
   /**
    * If the station is configured for persistent connection and an active connection is required to go on queue,
    * a "fake" call will be used to establish the persistent connection as part of the process to go on queue.
-   * This setting is additional configuration for how the webrtc sdk handles this circumstance but
-   * only comes into play if `disableAutoAnswer` is `true`. If `disableAutoAnswer` is `false`, `eagerPersistentConnectionEstablishment`
-   * will always be `'auto'`.
+   * This setting is additional configuration for how the webrtc sdk handles this circumstance.
    *
    * Options:
    * ``` ts


### PR DESCRIPTION
I put some commentary in the ticket, but I'll put some here, too.

For future changes, I was hopeful that a refactor of `handlePropose` would make it easier to do correctly. I also noticed that some of the comments and logs didn't reflect the implementation as closely as I thought they should. And because this is a significant change of the code organization, I personally felt it was worth having a separate review to discuss the rationale (and having that exist for future code spelunking).

I find this version easier to reason about. While it's a bit more nested, I think it's easier to trace any path and see how it compares to any other path of execution. And even though I mostly left the comments (and added one), the intent of the code is more obvious to me without relying on them. There's a mild exception with `super.handlePropose()` because we use it to emit the event, and that isn't obvious from the naming. Finally, I like that this codifies in code the comment that says we'll never have both `auto-answer` and `priv-answer-mode: Auto` at the same time (we could probably remove the comment, but I appreciated it to give some guidance that this is currently the case).

### MERGE CHECKLIST

- [x] Tests have been updated, added, or removed and the testing matrix has passed.
- [x] Documentation has been updated or added.
- [x] Changelog has been updated with ticket or issue number, link to the ticket, and a description of the changes.
- [x] Branch has been built in the BitBucket wrapper repository.
- [x] Pull request title is formatted as `[STREAM-<ticket number>] - <description of changes>` or `[<issue number>] - <description of changes>`.
- [ ] Release pull requests include someone from the PureScale team for approval.
  - [ ] Build release branch in wrapper repository and make sure it is tagged with `next` on npm.

