### PR TITLE
[STREAM-1180] Adjust media handling based on alerting leader

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Added documentation for live screen monitoring functionality
+* [STREAM-1180](https://inindca.atlassian.net/browse/STREAM-1180) - Allow for different media handling strategies. This supports alerting leader functionality, where one instance of the SDK needs to handle media, but other instances should not automatically handle media.
 
 ### Fixed
 * [STREAM-905](https://inindca.atlassian.net/browse/STREAM-905) - Fix issue where `sessionStarted` was not emitted for calls that re-use persistent connections after a media recovery has occurred. Now initializing `_emittedSessionStarteds` for reinvites but only emitting if not a reinvite.

--- a/src/client.ts
+++ b/src/client.ts
@@ -44,6 +44,7 @@ import { HeadsetProxyService } from './headsets/headset';
 import { Constants } from 'stanza';
 import { setupWebrtcForWindows11 } from './windows11-first-session-hack';
 import { ISdkHeadsetService } from './headsets/headset-types';
+import { SoftphoneSessionHandler } from '.';
 
 const ENVIRONMENTS = [
   'mypurecloud.com',
@@ -111,7 +112,7 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
   _customerData: ICustomerData;
   _hasConnected: boolean;
   _config: ISdkFullConfig;
-  _mediaHandling = MediaHandling.media;
+  _mediaHandling = MediaHandling.standardMedia;
 
   get isInitialized (): boolean {
     return !!this._streamingConnection;
@@ -863,25 +864,41 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
     this.media.setDefaultAudioStream(stream);
   }
 
+  /**
+   * **Genesys internal use only** - non-Genesys apps may experience unexpected behavior.
+   *
+   * Change the media handling for softphone sessions, which should be
+   * be chosen based on the alerting leader status of the consuming client.
+   *
+   * If media handling is reduced, idle persistent connections will be
+   * disconnected.
+   *
+   * @param mediaHandling how softphone media should be handled
+   */
   setMediaHandling (mediaHandling: MediaHandling): void {
+    const activeConversations = this.sessionManager.getAllActiveConversations();
+    console.log('Hjon: mediaHandling:', mediaHandling);
+    const useHeadsets = !(mediaHandling === MediaHandling.reducedMediaNoHeadsets);
+    console.log('Hjon: useHeadsets:', useHeadsets);
+
+    if (activeConversations.length !== 0 && !useHeadsets) {
+      throw createAndEmitSdkError.call(this, SdkErrorTypes.not_supported, 'Cannot downgrade media handling to stop using headsets during an active call');
+    }
+
     this._mediaHandling = mediaHandling;
+    this.setUseHeadsets(useHeadsets);
 
-    // The intent behind this comes from requirements for alerting leader
-    // where a client shouldn't handle media (mostly) if it isn't the alerting
-    // leader. Ideally this would only handle outbound calls, but we can't
-    // distinguish between outbound calls and inbound autoanswer ACD calls when
-    // we receive the `propose`.
-    if (mediaHandling === MediaHandling.autoAnswerOnly) {
-      this.setUseHeadsets(false);
-
-      // Disconnect any persistent connections we might have
-      this.sessionManager.getAllActiveSessions()
-        .filter(session => session.sessionType === SessionTypes.softphone)
-        .forEach(softphoneSession => {
-          this.sessionManager.forceTerminateSession(softphoneSession.id);
-        });
-    } else {
-      this.setUseHeadsets(true);
+    const reduceMediaHandling = mediaHandling === MediaHandling.reducedMediaHeadsets || mediaHandling === MediaHandling.reducedMediaNoHeadsets;
+    if (reduceMediaHandling) {
+      const conversationSessionIds = activeConversations.map(conversation => conversation.sessionId);
+      // Disconnect connections that aren't associated with an active conversation.
+      // When a client is no longer the alerting leader, it needs to give up any
+      // persistent connections. Active calls should be maintained.
+      this.sessionManager.getAllSessions().forEach(session => {
+        if (session.sessionType === SessionTypes.softphone && !conversationSessionIds.includes(session.id)) {
+          this.sessionManager.forceTerminateSession(session.id);
+        }
+      });
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -865,6 +865,15 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
 
   setMediaHandling (mediaHandling: MediaHandling): void {
     this._mediaHandling = mediaHandling;
+
+    if (mediaHandling === MediaHandling.noMedia) {
+      // Disconnect any persistent connections we might have
+      this.sessionManager.getAllActiveSessions()
+        .filter(session => session.sessionType === SessionTypes.softphone)
+        .forEach(softphoneSession => {
+          this.sessionManager.forceTerminateSession(softphoneSession.id);
+        });
+    }
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -876,10 +876,15 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
    * @param mediaHandling how softphone media should be handled
    */
   setMediaHandling (mediaHandling: MediaHandling): void {
-    const activeConversations = this.sessionManager.getAllActiveConversations();
-    console.log('Hjon: mediaHandling:', mediaHandling);
     const useHeadsets = !(mediaHandling === MediaHandling.reducedMediaNoHeadsets);
-    console.log('Hjon: useHeadsets:', useHeadsets);
+
+    if (!this.sessionManager) {
+      this._mediaHandling = mediaHandling;
+      this.setUseHeadsets(useHeadsets);
+      return;
+    }
+
+    const activeConversations = this.sessionManager.getAllActiveConversations();
 
     if (activeConversations.length !== 0 && !useHeadsets) {
       throw createAndEmitSdkError.call(this, SdkErrorTypes.not_supported, 'Cannot downgrade media handling to stop using headsets during an active call');

--- a/src/client.ts
+++ b/src/client.ts
@@ -37,7 +37,7 @@ import {
 } from './client-private';
 import { requestApi, createAndEmitSdkError, defaultConfigOption, requestApiWithRetry } from './utils';
 import { setupLogging } from './logging';
-import { SdkErrorTypes, SessionTypes } from './types/enums';
+import { MediaHandling, SdkErrorTypes, SessionTypes } from './types/enums';
 import { SessionManager } from './sessions/session-manager';
 import { SdkMedia } from './media/media';
 import { HeadsetProxyService } from './headsets/headset';
@@ -111,6 +111,7 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
   _customerData: ICustomerData;
   _hasConnected: boolean;
   _config: ISdkFullConfig;
+  _mediaHandling = MediaHandling.media;
 
   get isInitialized (): boolean {
     return !!this._streamingConnection;
@@ -860,6 +861,10 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
    */
   setDefaultAudioStream (stream?: MediaStream): void {
     this.media.setDefaultAudioStream(stream);
+  }
+
+  setMediaHandling (mediaHandling: MediaHandling): void {
+    this._mediaHandling = mediaHandling;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -866,7 +866,12 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
   setMediaHandling (mediaHandling: MediaHandling): void {
     this._mediaHandling = mediaHandling;
 
-    if (mediaHandling === MediaHandling.noMedia) {
+    // The intent behind this comes from requirements for alerting leader
+    // where a client shouldn't handle media (mostly) if it isn't the alerting
+    // leader. Ideally this would only handle outbound calls, but we can't
+    // distinguish between outbound calls and inbound autoanswer ACD calls when
+    // we receive the `propose`.
+    if (mediaHandling === MediaHandling.autoAnswerOnly) {
       this.setUseHeadsets(false);
 
       // Disconnect any persistent connections we might have

--- a/src/client.ts
+++ b/src/client.ts
@@ -867,12 +867,16 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
     this._mediaHandling = mediaHandling;
 
     if (mediaHandling === MediaHandling.noMedia) {
+      this.setUseHeadsets(false);
+
       // Disconnect any persistent connections we might have
       this.sessionManager.getAllActiveSessions()
         .filter(session => session.sessionType === SessionTypes.softphone)
         .forEach(softphoneSession => {
           this.sessionManager.forceTerminateSession(softphoneSession.id);
         });
+    } else {
+      this.setUseHeadsets(true);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -876,7 +876,7 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
    * @param mediaHandling how softphone media should be handled
    */
   setMediaHandling (mediaHandling: MediaHandling): void {
-    const useHeadsets = !(mediaHandling === MediaHandling.reducedMediaNoHeadsets);
+    const useHeadsets = !(mediaHandling === MediaHandling.reducedMedia);
 
     if (!this.sessionManager) {
       this._mediaHandling = mediaHandling;
@@ -887,13 +887,15 @@ export class GenesysCloudWebrtcSdk extends (EventEmitter as { new(): StrictEvent
     const activeConversations = this.sessionManager.getAllActiveConversations();
 
     if (activeConversations.length !== 0 && !useHeadsets) {
+      this._mediaHandling = MediaHandling.reducedMediaHeadsets;
+      this.setUseHeadsets(true);
       throw createAndEmitSdkError.call(this, SdkErrorTypes.not_supported, 'Cannot downgrade media handling to stop using headsets during an active call');
     }
 
     this._mediaHandling = mediaHandling;
     this.setUseHeadsets(useHeadsets);
 
-    const reduceMediaHandling = mediaHandling === MediaHandling.reducedMediaHeadsets || mediaHandling === MediaHandling.reducedMediaNoHeadsets;
+    const reduceMediaHandling = mediaHandling === MediaHandling.reducedMediaHeadsets || mediaHandling === MediaHandling.reducedMedia;
     if (reduceMediaHandling) {
       const conversationSessionIds = activeConversations.map(conversation => conversation.sessionId);
       // Disconnect connections that aren't associated with an active conversation.

--- a/src/headsets/headset.ts
+++ b/src/headsets/headset.ts
@@ -161,7 +161,7 @@ export class HeadsetProxyService implements ISdkHeadsetService {
         requestType
       }
     };
-    
+
     this.sdk._streamingConnection.messenger.broadcastMessage({
       mediaMessage: headsetControlsRequest
     });
@@ -176,7 +176,7 @@ export class HeadsetProxyService implements ISdkHeadsetService {
     if (state === this.orchestrationState && !forceUpdate) {
       return;
     }
-    
+
     this.sdk.logger.debug('Headset Orchestration state change', { oldState: this.orchestrationState, newState: state });
 
     if (state === 'alternativeClient') {
@@ -201,7 +201,7 @@ export class HeadsetProxyService implements ISdkHeadsetService {
     if (msg.fromMyClient) {
       return;
     }
-    
+
     switch(msg.mediaMessage.method) {
       case 'headsetControlsRequest':
         this.handleHeadsetControlsRequest(msg);
@@ -234,6 +234,9 @@ export class HeadsetProxyService implements ISdkHeadsetService {
       // we still yield to media-helper
       if (this.getRequestPriority(mediaMessage.params.requestType) === this.getRequestPriority('mediaHelper')) {
         this.sdk.logger.info('Handling alerting leader media, but yielding headset controls to media-helper', { requestType: mediaMessage.params.requestType });
+        this.setOrchestrationState('alternativeClient');
+      } else if (this.getRequestPriority(mediaMessage.params.requestType) === this.getRequestPriority('prioritized')) {
+        this.sdk.logger.info('Currently handling alerting leader media, but yielding headset controls to new alerting leader', { requestType: mediaMessage.params.requestType });
         this.setOrchestrationState('alternativeClient');
       } else {
         this.sendControlsRejectionMessage(msg, 'priority');
@@ -336,7 +339,7 @@ export class HeadsetProxyService implements ISdkHeadsetService {
   endAllCalls (): Promise<void> {
     return this.currentHeadsetService.endAllCalls();
   }
-  
+
   answerIncomingCall (conversationId: string, autoAnswer: boolean): Promise<void> {
     return this.currentHeadsetService.answerIncomingCall(conversationId, autoAnswer);
   }

--- a/src/headsets/headset.ts
+++ b/src/headsets/headset.ts
@@ -9,6 +9,7 @@ import { SdkHeadsetService } from './sdk-headset-service';
 import { HeadsetRequestType } from '../types/interfaces';
 import { ExpandedConsumedHeadsetEvents, ISdkHeadsetService, OrchestrationState } from './headset-types';
 import { HeadsetChangesQueue } from './headset-utils';
+import { MediaHandling } from '../types/enums';
 
 const REQUEST_PRIORITY: {[key in HeadsetControlsRequestType]: number} = {
   'mediaHelper': 30,
@@ -216,6 +217,18 @@ export class HeadsetProxyService implements ISdkHeadsetService {
   private handleHeadsetControlsRequest (msg: MediaMessageEvent) {
     const mediaMessage = msg.mediaMessage as HeadsetControlsRequest;
     this.sdk.logger.debug('Received headsetControlsRequest message', { requestType: mediaMessage.params.requestType });
+
+    if (this.sdk._mediaHandling === MediaHandling.alertingLeaderMedia) {
+      // we still yield to media-helper
+      if (this.getRequestPriority(mediaMessage.params.requestType) === this.getRequestPriority('mediaHelper')) {
+        this.sdk.logger.info('Handling alerting leader media, but yielding headset controls to media-helper', { requestType: mediaMessage.params.requestType });
+        this.setOrchestrationState('alternativeClient');
+      } else {
+        this.sendControlsRejectionMessage(msg, 'priority');
+      }
+
+      return;
+    }
 
     // if incoming request is lower priority, reject
     if (this.getRequestPriority(mediaMessage.params.requestType) < this.getRequestPriority(this.sdk._config.headsetRequestType)) {

--- a/src/headsets/headset.ts
+++ b/src/headsets/headset.ts
@@ -49,7 +49,7 @@ export class HeadsetProxyService implements ISdkHeadsetService {
     // TODO: PCM-2060 - remove this
     this.useHeadsetOrchestration = !this.sdk._config.disableHeadsetControlsOrchestration;
 
-    if (this.sdk._mediaHandling === MediaHandling.noMedia) {
+    if (this.sdk._mediaHandling === MediaHandling.autoAnswerOnly) {
       this.sdk.logger.warn('setUseHeadsets was called with `true` but headsets are not supported in this configuration - not handling media. Not activating headsets.');
       useHeadsets = false;
     }

--- a/src/headsets/headset.ts
+++ b/src/headsets/headset.ts
@@ -49,10 +49,15 @@ export class HeadsetProxyService implements ISdkHeadsetService {
     // TODO: PCM-2060 - remove this
     this.useHeadsetOrchestration = !this.sdk._config.disableHeadsetControlsOrchestration;
 
+    if (this.sdk._mediaHandling === MediaHandling.noMedia) {
+      this.sdk.logger.warn('setUseHeadsets was called with `true` but headsets are not supported in this configuration - not handling media. Not activating headsets.');
+      useHeadsets = false;
+    }
+
     // currently only softphone is supported
     const headsetsIsSupported = this.sdk._config.allowedSessionTypes.includes(SessionTypes.softphone);
     if (useHeadsets && !headsetsIsSupported) {
-      this.sdk.logger.warn('setUseHeadsets was called with `true` but headsets are not supported in this configuration. Not activating headsets.');
+      this.sdk.logger.warn('setUseHeadsets was called with `true` but headsets are not supported in this configuration - headset is not supported. Not activating headsets.');
       useHeadsets = false;
     }
 

--- a/src/headsets/headset.ts
+++ b/src/headsets/headset.ts
@@ -49,8 +49,8 @@ export class HeadsetProxyService implements ISdkHeadsetService {
     // TODO: PCM-2060 - remove this
     this.useHeadsetOrchestration = !this.sdk._config.disableHeadsetControlsOrchestration;
 
-    if (this.sdk._mediaHandling === MediaHandling.reducedMediaNoHeadsets) {
-      this.sdk.logger.warn('setUseHeadsets was called with `true` but media handling is set to `reducedMediaNoHeadsets`; headsets are not supported in this configuration - not handling media. Not activating headsets.');
+    if (this.sdk._mediaHandling === MediaHandling.reducedMedia) {
+      this.sdk.logger.warn('setUseHeadsets was called with `true` but media handling is set to `reducedMedia`; headsets are not supported in this configuration - not handling media. Not activating headsets.');
       useHeadsets = false;
     }
 

--- a/src/headsets/headset.ts
+++ b/src/headsets/headset.ts
@@ -142,11 +142,18 @@ export class HeadsetProxyService implements ISdkHeadsetService {
 
     this.sdk.logger.info('Starting headsetCallControls orchestration');
 
+    let requestType: HeadsetControlsRequestType;
+    if (this.sdk._mediaHandling === MediaHandling.alertingLeaderMedia) {
+      requestType = 'prioritized';
+    } else {
+      requestType = this.sdk._config.headsetRequestType || 'standard';
+    }
+
     const headsetControlsRequest: HeadsetControlsRequest = {
       jsonrpc: '2.0',
       method: 'headsetControlsRequest',
       params: {
-        requestType: this.sdk._config.headsetRequestType || 'standard'
+        requestType
       }
     };
     

--- a/src/headsets/headset.ts
+++ b/src/headsets/headset.ts
@@ -49,8 +49,8 @@ export class HeadsetProxyService implements ISdkHeadsetService {
     // TODO: PCM-2060 - remove this
     this.useHeadsetOrchestration = !this.sdk._config.disableHeadsetControlsOrchestration;
 
-    if (this.sdk._mediaHandling === MediaHandling.autoAnswerOnly) {
-      this.sdk.logger.warn('setUseHeadsets was called with `true` but headsets are not supported in this configuration - not handling media. Not activating headsets.');
+    if (this.sdk._mediaHandling === MediaHandling.reducedMediaNoHeadsets) {
+      this.sdk.logger.warn('setUseHeadsets was called with `true` but media handling is set to `reducedMediaNoHeadsets`; headsets are not supported in this configuration - not handling media. Not activating headsets.');
       useHeadsets = false;
     }
 

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -149,36 +149,49 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
   async handlePropose (pendingSession: IPendingSession): Promise<void> {
     const isPrivAnswerAuto = pendingSession.privAnswerMode === 'Auto';
     const eagerConnectionEstablishmentMode = this.sdk._config.eagerPersistentConnectionEstablishment;
+    const autoAnswerOnly = this.sdk._mediaHandling === MediaHandling.autoAnswerOnly;
     const logInfo = { sessionId: pendingSession?.id, conversationId: pendingSession.conversationId };
 
-    if (this.sdk._mediaHandling === MediaHandling.noMedia) {
-      this.log('info', 'media handling is set to "no-media" so propose will be ignored', logInfo);
-      return;
-    }
-
-    if (isPrivAnswerAuto) {
-      this.log('info', 'received a propose with privAnswerMode=Auto', logInfo);
-
-      if (eagerConnectionEstablishmentMode === 'none') {
-        this.log('info', 'eagerPersistentConnectionEstablishment is "none" so propose with privAnswerMode=Auto will be ignored', logInfo);
-        return;
-      } else if (eagerConnectionEstablishmentMode === 'auto') {
-        // we don't need to emit a pendingSession event when we auto-answer eager persistent connections
-        return await this.proceedWithSession(pendingSession);
-      } else {
-        await super.handlePropose(pendingSession);
-      }
-    } else {
-      // we want to emit the pendingSession event in all other cases
-      await super.handlePropose(pendingSession);
-
-      // calls will can be marked as auto-answer or priv-answer-mode: Auto, but never both
+    if (autoAnswerOnly) {
       if (pendingSession.autoAnswer) {
+        // emit the pendingSession event
+        await super.handlePropose(pendingSession);
+
         if (this.sdk._config.disableAutoAnswer) {
           // It is possible that the consuming client has its own logic for auto-answering calls (e.g. web-dir).
           this.log('info', 'received an autoAnswer tagged propose but the SDK was configured to not auto-answer, deferring to the consuming client.', logInfo);
         } else {
           await this.proceedWithSession(pendingSession);
+        }
+      } else {
+        this.log('info', 'media handling is set to "auto-answer-only", but this propose is not marked as autoAnswer and will be ignored', logInfo);
+        return;
+      }
+    } else {
+      if (isPrivAnswerAuto) {
+        this.log('info', 'received a propose with privAnswerMode=Auto', logInfo);
+
+        if (eagerConnectionEstablishmentMode === 'none') {
+          this.log('info', 'eagerPersistentConnectionEstablishment is "none" so propose with privAnswerMode=Auto will be ignored', logInfo);
+          return;
+        } else if (eagerConnectionEstablishmentMode === 'auto') {
+          // we don't need to emit a pendingSession event when we auto-answer eager persistent connections
+          return await this.proceedWithSession(pendingSession);
+        } else {
+          await super.handlePropose(pendingSession);
+        }
+      } else {
+        // we want to emit the pendingSession event in all other cases
+        await super.handlePropose(pendingSession);
+
+        // calls will can be marked as auto-answer or priv-answer-mode: Auto, but never both
+        if (pendingSession.autoAnswer) {
+          if (this.sdk._config.disableAutoAnswer) {
+            // It is possible that the consuming client has its own logic for auto-answering calls (e.g. web-dir).
+            this.log('info', 'received an autoAnswer tagged propose but the SDK was configured to not auto-answer, deferring to the consuming client.', logInfo);
+          } else {
+            await this.proceedWithSession(pendingSession);
+          }
         }
       }
     }

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -150,7 +150,7 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
     const isPrivAnswerAuto = pendingSession.privAnswerMode === 'Auto';
     const eagerConnectionEstablishmentMode = this.sdk._config.eagerPersistentConnectionEstablishment;
     const logInfo = { sessionId: pendingSession?.id, conversationId: pendingSession.conversationId };
-    const reducedMediaHandling = this.sdk._mediaHandling === MediaHandling.reducedMediaHeadsets || this.sdk._mediaHandling === MediaHandling.reducedMediaNoHeadsets;
+    const reducedMediaHandling = this.sdk._mediaHandling === MediaHandling.reducedMediaHeadsets || this.sdk._mediaHandling === MediaHandling.reducedMedia;
 
     if (reducedMediaHandling) {
       this.log('info', 'received a propose while the SDK is configured for reduced media handling', logInfo);

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -19,7 +19,7 @@ import {
   PersistentConnectionEvent,
   HawkNotification
 } from '../types/interfaces';
-import { SessionTypes, SdkErrorTypes, JingleReasons, CommunicationStates } from '../types/enums';
+import { SessionTypes, SdkErrorTypes, JingleReasons, CommunicationStates, MediaHandling } from '../types/enums';
 import { attachAudioMedia, logDeviceChange, createUniqueAudioMediaElement } from '../media/media-utils';
 import { requestApi, isSoftphoneJid, createAndEmitSdkError, isPeerConnectionDisconnected } from '../utils';
 import { HeadsetChangesQueue } from '../headsets/headset-utils';
@@ -150,6 +150,11 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
     const isPrivAnswerAuto = pendingSession.privAnswerMode === 'Auto';
     const eagerConnectionEstablishmentMode = this.sdk._config.eagerPersistentConnectionEstablishment;
     const logInfo = { sessionId: pendingSession?.id, conversationId: pendingSession.conversationId };
+
+    if (this.sdk._mediaHandling === MediaHandling.noMedia) {
+      this.log('info', 'media handling is set to "no-media" so propose will be ignored', logInfo);
+      return;
+    }
 
     if (isPrivAnswerAuto) {
       this.log('info', 'received a propose with privAnswerMode=Auto', logInfo);

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -149,10 +149,12 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
   async handlePropose (pendingSession: IPendingSession): Promise<void> {
     const isPrivAnswerAuto = pendingSession.privAnswerMode === 'Auto';
     const eagerConnectionEstablishmentMode = this.sdk._config.eagerPersistentConnectionEstablishment;
-    const autoAnswerOnly = this.sdk._mediaHandling === MediaHandling.autoAnswerOnly;
     const logInfo = { sessionId: pendingSession?.id, conversationId: pendingSession.conversationId };
+    const reducedMediaHandling = this.sdk._mediaHandling === MediaHandling.reducedMediaHeadsets || this.sdk._mediaHandling === MediaHandling.reducedMediaNoHeadsets;
 
-    if (autoAnswerOnly) {
+    if (reducedMediaHandling) {
+      this.log('info', 'received a propose while the SDK is configured for reduced media handling', logInfo);
+
       if (pendingSession.autoAnswer) {
         // emit the pendingSession event
         await super.handlePropose(pendingSession);
@@ -164,7 +166,7 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
           await this.proceedWithSession(pendingSession);
         }
       } else {
-        this.log('info', 'media handling is set to "auto-answer-only", but this propose is not marked as autoAnswer and will be ignored', logInfo);
+        this.log('info', 'media handling is reduced, but this propose is not marked as autoAnswer and will be ignored', logInfo);
         return;
       }
     } else {

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -45,12 +45,26 @@ export enum JingleReasons {
   alternativeSession = 'alternative-session'
 }
 
+/** These currently only affect softphone media */
 export enum MediaHandling {
   /** Handle all media; headset controls use traditional orchestration */
-  media = 'media',
+  standardMedia = 'standard-media',
   /** Handle all media; headset controls follow alerting leader */
   alertingLeaderMedia = 'alerting-leader-media',
-  /** Only handle autoAnswer calls; headset controls are not used */
-  // Ideally we would only allow outbound calls, but currently we can't distinguish between an outbound call and an inbound autoanswer ACD call
-  autoAnswerOnly = 'auto-answer-only'
+  /**
+   * Handle some media (see below); headset controls use traditional orchestration
+   *
+   * - New eager persistent connections will be ignored.
+   * - Auto-answer calls will be handled, which could result in a
+   * persistent connection being established.
+   */
+  reducedMediaHeadsets = 'reduced-media-headsets',
+  /**
+   * Handle some media (see below); headset controls are not used
+   *
+   * - New eager persistent connections will be ignored.
+   * - Auto-answer calls will be handled, which could result in a
+   * persistent connection being established.
+   */
+  reducedMediaNoHeadsets = 'reduced-media-no-headsets',
 }

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -52,19 +52,19 @@ export enum MediaHandling {
   /** Handle all media; headset controls follow alerting leader */
   alertingLeaderMedia = 'alerting-leader-media',
   /**
-   * Handle some media (see below); headset controls use traditional orchestration
-   *
-   * - New eager persistent connections will be ignored.
-   * - Auto-answer calls will be handled, which could result in a
-   * persistent connection being established.
-   */
-  reducedMediaHeadsets = 'reduced-media-headsets',
-  /**
    * Handle some media (see below); headset controls are not used
    *
    * - New eager persistent connections will be ignored.
    * - Auto-answer calls will be handled, which could result in a
    * persistent connection being established.
    */
-  reducedMediaNoHeadsets = 'reduced-media-no-headsets',
+  reducedMedia = 'reduced-media',
+  /**
+   * Internal use only. Handle some media (see below); headset controls use traditional orchestration.
+   *
+   * - New eager persistent connections will be ignored.
+   * - Auto-answer calls will be handled, which could result in a
+   * persistent connection being established.
+   */
+  reducedMediaHeadsets = 'reduced-media-headsets',
 }

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -60,7 +60,7 @@ export enum MediaHandling {
    */
   reducedMedia = 'reduced-media',
   /**
-   * Internal use only. Handle some media (see below); headset controls use traditional orchestration.
+   * SDK internal use only. Handle some media (see below); headset controls use traditional orchestration.
    *
    * - New eager persistent connections will be ignored.
    * - Auto-answer calls will be handled, which could result in a

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -46,7 +46,11 @@ export enum JingleReasons {
 }
 
 export enum MediaHandling {
+  /** Handle all media; headset controls use traditional orchestration */
   media = 'media',
+  /** Handle all media; headset controls follow alerting leader */
   alertingLeaderMedia = 'alerting-leader-media',
-  noMedia = 'no-media'
+  /** Only handle autoAnswer calls; headset controls are not used */
+  // Ideally we would only allow outbound calls, but currently we can't distinguish between an outbound call and an inbound autoanswer ACD call
+  autoAnswerOnly = 'auto-answer-only'
 }

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -44,3 +44,9 @@ export enum JingleReasons {
   connectivityError = 'connectivity-error',
   alternativeSession = 'alternative-session'
 }
+
+export enum MediaHandling {
+  media = 'media',
+  alertingLeaderMedia = 'alerting-leader-media',
+  noMedia = 'no-media'
+}

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -1161,7 +1161,7 @@ describe('Client', () => {
   });
 
   describe('setMediaHandling()', () => {
-    it('should stop using headsets and disconnect any active sessions when set to "noMedia"', () => {
+    it('should stop using headsets and disconnect any active sessions when set to "autoAnswerOnly"', () => {
       sdk = constructSdk();
       const useHeadsetsSpy = jest.fn();
       sdk.setUseHeadsets = useHeadsetsSpy;
@@ -1172,7 +1172,7 @@ describe('Client', () => {
       const forceTerminateSpy = jest.fn();
       sessionManagerMock.forceTerminateSession = forceTerminateSpy;
 
-      sdk.setMediaHandling(MediaHandling.noMedia);
+      sdk.setMediaHandling(MediaHandling.autoAnswerOnly);
 
       expect(useHeadsetsSpy).toHaveBeenCalledWith(false);
       expect(forceTerminateSpy).toHaveBeenCalledWith(sessionId);

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -1161,8 +1161,10 @@ describe('Client', () => {
   });
 
   describe('setMediaHandling()', () => {
-    it('should disconnect any active sessions when set to "noMedia"', () => {
+    it('should stop using headsets and disconnect any active sessions when set to "noMedia"', () => {
       sdk = constructSdk();
+      const useHeadsetsSpy = jest.fn();
+      sdk.setUseHeadsets = useHeadsetsSpy;
       const mockSession = new MockSession(SessionTypes.softphone);
       const sessionId = mockSession.id;
       const sessions = [mockSession] as unknown as IExtendedMediaSession[];
@@ -1172,7 +1174,20 @@ describe('Client', () => {
 
       sdk.setMediaHandling(MediaHandling.noMedia);
 
+      expect(useHeadsetsSpy).toHaveBeenCalledWith(false);
       expect(forceTerminateSpy).toHaveBeenCalledWith(sessionId);
+    });
+
+    it('should use headsets when handling any media', () => {
+      sdk = constructSdk();
+      const useHeadsetsSpy = jest.fn();
+      sdk.setUseHeadsets = useHeadsetsSpy;
+
+      sdk.setMediaHandling(MediaHandling.media);
+      expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
+
+      sdk.setMediaHandling(MediaHandling.alertingLeaderMedia);
+      expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
     });
   });
 

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -1174,15 +1174,15 @@ describe('Client', () => {
       expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
     });
 
-    it('should throw if media handling will not use headsets but there is an active conversation', () => {
+    it('should throw and reduce media handling if new media handling will not use headsets but there is an active conversation', () => {
       sdk = constructSdk();
       const conversations = [{ conversationId: 'test-conversation-id' }] as IActiveConversationDescription[];
       sessionManagerMock.getAllActiveConversations.mockReturnValue(conversations);
 
       expect(() => {
-        sdk.setMediaHandling(MediaHandling.reducedMediaNoHeadsets);
+        sdk.setMediaHandling(MediaHandling.reducedMedia);
       }).toThrow();
-      expect(sdk._mediaHandling).toBe(MediaHandling.standardMedia);
+      expect(sdk._mediaHandling).toBe(MediaHandling.reducedMediaHeadsets);
     });
 
     it('should disconnect any sessions not connected to an active conversation when set to a reduced handling of media', () => {

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -30,7 +30,8 @@ import {
   IPersonDetails,
   ISessionIdAndConversationId,
   VideoSessionHandler,
-  MediaHandling
+  MediaHandling,
+  IActiveConversationDescription
 } from '../../src';
 import * as utils from '../../src/utils';
 import { RetryPromise } from 'genesys-cloud-streaming-client/dist/es/utils';
@@ -1161,32 +1162,49 @@ describe('Client', () => {
   });
 
   describe('setMediaHandling()', () => {
-    it('should stop using headsets and disconnect any active sessions when set to "autoAnswerOnly"', () => {
+    it('should throw if media handling will not use headsets but there is an active conversation', () => {
       sdk = constructSdk();
-      const useHeadsetsSpy = jest.fn();
-      sdk.setUseHeadsets = useHeadsetsSpy;
+      const conversations = [{ conversationId: 'test-conversation-id' }] as IActiveConversationDescription[];
+      sessionManagerMock.getAllActiveConversations.mockReturnValue(conversations);
+
+      expect(() => {
+        sdk.setMediaHandling(MediaHandling.reducedMediaNoHeadsets);
+      }).toThrow();
+    });
+
+    it('should disconnect any sessions not connected to an active conversation when set to a reduced handling of media', () => {
+      sdk = constructSdk();
+      sdk.setUseHeadsets = jest.fn();
+
       const mockSession = new MockSession(SessionTypes.softphone);
-      const sessionId = mockSession.id;
-      const sessions = [mockSession] as unknown as IExtendedMediaSession[];
-      sessionManagerMock.getAllActiveSessions.mockReturnValue(sessions);
+      const conversations = [{ sessionId: mockSession.id }] as IActiveConversationDescription[];
+      sessionManagerMock.getAllActiveConversations.mockReturnValue(conversations);
+      const idleSession = new MockSession(SessionTypes.softphone);
+      const idleSessionId = idleSession.id;
+      const sessions = [mockSession, idleSession] as unknown as IExtendedMediaSession[];
+      sessionManagerMock.getAllSessions.mockReturnValue(sessions);
       const forceTerminateSpy = jest.fn();
       sessionManagerMock.forceTerminateSession = forceTerminateSpy;
 
-      sdk.setMediaHandling(MediaHandling.autoAnswerOnly);
+      sdk.setMediaHandling(MediaHandling.reducedMediaHeadsets);
 
-      expect(useHeadsetsSpy).toHaveBeenCalledWith(false);
-      expect(forceTerminateSpy).toHaveBeenCalledWith(sessionId);
+      expect(forceTerminateSpy).toHaveBeenCalledTimes(1);
+      expect(forceTerminateSpy).toHaveBeenCalledWith(idleSessionId);
     });
 
     it('should use headsets when handling any media', () => {
       sdk = constructSdk();
+      sessionManagerMock.getAllActiveConversations.mockReturnValue([]);
       const useHeadsetsSpy = jest.fn();
       sdk.setUseHeadsets = useHeadsetsSpy;
 
-      sdk.setMediaHandling(MediaHandling.media);
+      sdk.setMediaHandling(MediaHandling.standardMedia);
       expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
 
       sdk.setMediaHandling(MediaHandling.alertingLeaderMedia);
+      expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
+
+      sdk.setMediaHandling(MediaHandling.reducedMediaHeadsets);
       expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
     });
   });

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -29,7 +29,8 @@ import {
   IStation,
   IPersonDetails,
   ISessionIdAndConversationId,
-  VideoSessionHandler
+  VideoSessionHandler,
+  MediaHandling
 } from '../../src';
 import * as utils from '../../src/utils';
 import { RetryPromise } from 'genesys-cloud-streaming-client/dist/es/utils';
@@ -1156,6 +1157,22 @@ describe('Client', () => {
 
       sdk.setDefaultAudioStream(media);
       expect(spy).toHaveBeenCalledWith(media);
+    });
+  });
+
+  describe('setMediaHandling()', () => {
+    it('should disconnect any active sessions when set to "noMedia"', () => {
+      sdk = constructSdk();
+      const mockSession = new MockSession(SessionTypes.softphone);
+      const sessionId = mockSession.id;
+      const sessions = [mockSession] as unknown as IExtendedMediaSession[];
+      sessionManagerMock.getAllActiveSessions.mockReturnValue(sessions);
+      const forceTerminateSpy = jest.fn();
+      sessionManagerMock.forceTerminateSession = forceTerminateSpy;
+
+      sdk.setMediaHandling(MediaHandling.noMedia);
+
+      expect(forceTerminateSpy).toHaveBeenCalledWith(sessionId);
     });
   });
 

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -1162,6 +1162,18 @@ describe('Client', () => {
   });
 
   describe('setMediaHandling()', () => {
+    it('should just set media handling and headsets if there is no sessionManager yet', () => {
+      const mockSdk = constructSdk();
+      (sdk as any).sessionManager = null;
+      const useHeadsetsSpy = jest.fn();
+      mockSdk.setUseHeadsets = useHeadsetsSpy;
+
+      sdk.setMediaHandling(MediaHandling.reducedMediaHeadsets);
+
+      expect(sdk._mediaHandling).toBe(MediaHandling.reducedMediaHeadsets);
+      expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
+    });
+
     it('should throw if media handling will not use headsets but there is an active conversation', () => {
       sdk = constructSdk();
       const conversations = [{ conversationId: 'test-conversation-id' }] as IActiveConversationDescription[];
@@ -1170,6 +1182,7 @@ describe('Client', () => {
       expect(() => {
         sdk.setMediaHandling(MediaHandling.reducedMediaNoHeadsets);
       }).toThrow();
+      expect(sdk._mediaHandling).toBe(MediaHandling.standardMedia);
     });
 
     it('should disconnect any sessions not connected to an active conversation when set to a reduced handling of media', () => {
@@ -1188,6 +1201,7 @@ describe('Client', () => {
 
       sdk.setMediaHandling(MediaHandling.reducedMediaHeadsets);
 
+      expect(sdk._mediaHandling).toBe(MediaHandling.reducedMediaHeadsets);
       expect(forceTerminateSpy).toHaveBeenCalledTimes(1);
       expect(forceTerminateSpy).toHaveBeenCalledWith(idleSessionId);
     });
@@ -1199,12 +1213,15 @@ describe('Client', () => {
       sdk.setUseHeadsets = useHeadsetsSpy;
 
       sdk.setMediaHandling(MediaHandling.standardMedia);
+      expect(sdk._mediaHandling).toBe(MediaHandling.standardMedia);
       expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
 
       sdk.setMediaHandling(MediaHandling.alertingLeaderMedia);
+      expect(sdk._mediaHandling).toBe(MediaHandling.alertingLeaderMedia);
       expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
 
       sdk.setMediaHandling(MediaHandling.reducedMediaHeadsets);
+      expect(sdk._mediaHandling).toBe(MediaHandling.reducedMediaHeadsets);
       expect(useHeadsetsSpy).toHaveBeenCalledWith(true);
     });
   });

--- a/test/unit/headset/headset.test.ts
+++ b/test/unit/headset/headset.test.ts
@@ -301,8 +301,8 @@ describe('HeadsetProxyService', () => {
       expect(proxyService['currentHeadsetService']).toBeInstanceOf(SdkHeadsetServiceFake);
     });
 
-    it('should use fake service if useHeadsets and only handling autoAnswer calls', () => {
-      proxyService['sdk']._mediaHandling = MediaHandling.autoAnswerOnly;
+    it('should use fake service if useHeadsets and media is set to reducedMediaNoHeadsets', () => {
+      proxyService['sdk']._mediaHandling = MediaHandling.reducedMediaNoHeadsets;
       const spy = jest.spyOn(proxyService, 'updateAudioInputDevice');
 
       proxyService.setUseHeadsets(true);

--- a/test/unit/headset/headset.test.ts
+++ b/test/unit/headset/headset.test.ts
@@ -301,8 +301,8 @@ describe('HeadsetProxyService', () => {
       expect(proxyService['currentHeadsetService']).toBeInstanceOf(SdkHeadsetServiceFake);
     });
 
-    it('should use fake service if useHeadsets and media is set to reducedMediaNoHeadsets', () => {
-      proxyService['sdk']._mediaHandling = MediaHandling.reducedMediaNoHeadsets;
+    it('should use fake service if useHeadsets and media is set to reducedMedia', () => {
+      proxyService['sdk']._mediaHandling = MediaHandling.reducedMedia;
       const spy = jest.spyOn(proxyService, 'updateAudioInputDevice');
 
       proxyService.setUseHeadsets(true);

--- a/test/unit/headset/headset.test.ts
+++ b/test/unit/headset/headset.test.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import GenesysCloudWebrtSdk, { JingleReason, JingleReasonCondition } from "../../../src";
+import GenesysCloudWebrtSdk, { JingleReason, JingleReasonCondition, MediaHandling } from "../../../src";
 import HeadsetService, { ConsumedHeadsetEvents } from 'softphone-vendor-headsets';
 import { SimpleMockSdk, flushPromises } from '../../test-utils';
 import { SdkHeadsetService } from '../../../src/headsets/sdk-headset-service';
@@ -590,6 +590,36 @@ describe('HeadsetProxyService', () => {
       expect(proxyService['orchestrationState']).toBe('alternativeClient');
     });
 
+    it('should not take controls if a media-helper request is received during orchestration even if handling alerting leader media', async () => {
+      proxyService['sdk']._mediaHandling = MediaHandling.alertingLeaderMedia;
+
+      expect(proxyService['orchestrationWaitTimer']).toBeFalsy();
+      const promise = proxyService['startHeadsetOrchestration'](device);
+      await flushPromises();
+
+      broadcastSpy.mockReset();
+
+      expect(proxyService['orchestrationWaitTimer']).toBeTruthy();
+
+      // request is received 1 second after starting
+      jest.advanceTimersByTime(1000);
+      const request: HeadsetControlsRequest = {
+        jsonrpc: '2.0',
+        method: 'headsetControlsRequest',
+        params: {
+          requestType: 'mediaHelper',
+        }
+      };
+      triggerMediaMessageEvent({ to: 'to', from: 'from', mediaMessage: request, fromMyClient: false, fromMyUser: true });
+
+      expect(proxyService['orchestrationState']).toBe('alternativeClient');
+      jest.advanceTimersByTime(1500);
+
+      expect(updateAudioSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled()
+      expect(proxyService['orchestrationState']).toBe('alternativeClient');
+    });
+
     it('should send a rejection if a request is received during orchestration and is lower priority', async () => {
       expect(proxyService['orchestrationWaitTimer']).toBeFalsy();
 
@@ -711,6 +741,54 @@ describe('HeadsetProxyService', () => {
         }
       };
       expect(broadcastSpy).toHaveBeenCalledWith(expect.objectContaining({ mediaMessage: rejection }));
+    });
+
+    it('should send a rejection if a request is received while handling alerting leader media and is lower priority', async () => {
+      expect(proxyService['orchestrationWaitTimer']).toBeFalsy();
+
+      proxyService['sdk']._config.headsetRequestType = 'standard';
+      proxyService['sdk']._mediaHandling = MediaHandling.alertingLeaderMedia;
+
+      const promise = proxyService['startHeadsetOrchestration'](device);
+      await flushPromises();
+
+      broadcastSpy.mockReset();
+
+      expect(proxyService['orchestrationWaitTimer']).toBeTruthy();
+
+      // request is received 1 second after starting
+      jest.advanceTimersByTime(1000);
+      const request: HeadsetControlsRequest = {
+        jsonrpc: '2.0',
+        method: 'headsetControlsRequest',
+        params: {
+          requestType: 'standard',
+        }
+      };
+      triggerMediaMessageEvent({ id:'req1', to: 'to', from: 'from', mediaMessage: request, fromMyClient: false, fromMyUser: true });
+
+      jest.advanceTimersByTime(1500);
+
+      const rejection: HeadsetControlsRejection = {
+        jsonrpc: '2.0',
+        method: 'headsetControlsRejection',
+        params: {
+          reason: 'priority',
+          requestId: 'req1'
+        }
+      };
+      expect(broadcastSpy).toHaveBeenCalledWith(expect.objectContaining({ mediaMessage: rejection }));
+
+      expect(updateAudioSpy).toHaveBeenCalled();
+      const expectedMediaMessage: HeadsetControlsChanged = {
+        jsonrpc: '2.0',
+        method: 'headsetControlsChanged',
+        params: {
+          hasControls: true
+        }
+      };
+      expect(broadcastSpy).toHaveBeenCalledWith(expect.objectContaining({ mediaMessage: expectedMediaMessage }));
+      expect(proxyService['orchestrationState']).toBe('hasControls');
     });
 
     it('should do nothing if persistent connection but no active session', async () => {

--- a/test/unit/headset/headset.test.ts
+++ b/test/unit/headset/headset.test.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import GenesysCloudWebrtSdk, { JingleReason, JingleReasonCondition, MediaHandling } from "../../../src";
+import GenesysCloudWebrtSdk, { MediaHandling } from "../../../src";
 import HeadsetService, { ConsumedHeadsetEvents } from 'softphone-vendor-headsets';
 import { SimpleMockSdk, flushPromises } from '../../test-utils';
 import { SdkHeadsetService } from '../../../src/headsets/sdk-headset-service';
@@ -356,6 +356,21 @@ describe('HeadsetProxyService', () => {
       const vendor = {} as any;
       Object.defineProperty(currentHeadsetService, 'currentSelectedImplementation', { get: () => vendor });
       expect(proxyService.currentSelectedImplementation).toBe(vendor);
+    });
+  });
+
+  describe('startHeadsetOrchestration', () => {
+    it('should use "prioritized" requestType if handling alerting leader media', async () => {
+      const broadcastSpy = jest.fn();
+      proxyService['sdk']._streamingConnection.messenger.broadcastMessage = broadcastSpy;
+      proxyService['sdk']._mediaHandling = MediaHandling.alertingLeaderMedia;
+      const device = { deviceId: 'device1Id', groupId: 'device1GroupId', label: 'device1Label', kind: 'audioinput' } as any;
+
+      await proxyService['startHeadsetOrchestration'](device);
+
+      const expectedRequestSubset = { mediaMessage: { params: { requestType: 'prioritized' } } };
+      expect(broadcastSpy).toHaveBeenCalled();
+      expect(broadcastSpy.mock.lastCall[0]).toMatchObject(expectedRequestSubset);
     });
   });
 

--- a/test/unit/headset/headset.test.ts
+++ b/test/unit/headset/headset.test.ts
@@ -301,6 +301,16 @@ describe('HeadsetProxyService', () => {
       expect(proxyService['currentHeadsetService']).toBeInstanceOf(SdkHeadsetServiceFake);
     });
 
+    it('should use fake service if useHeadsets and not handling media', () => {
+      proxyService['sdk']._mediaHandling = MediaHandling.noMedia;
+      const spy = jest.spyOn(proxyService, 'updateAudioInputDevice');
+
+      proxyService.setUseHeadsets(true);
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(proxyService['currentHeadsetService']).toBeInstanceOf(SdkHeadsetServiceFake);
+    });
+
     it('should unsubscribe if currentEventSubscription', () => {
       const spy = jest.fn();
       proxyService['currentEventSubscription'] = { unsubscribe: spy } as any;

--- a/test/unit/headset/headset.test.ts
+++ b/test/unit/headset/headset.test.ts
@@ -301,8 +301,8 @@ describe('HeadsetProxyService', () => {
       expect(proxyService['currentHeadsetService']).toBeInstanceOf(SdkHeadsetServiceFake);
     });
 
-    it('should use fake service if useHeadsets and not handling media', () => {
-      proxyService['sdk']._mediaHandling = MediaHandling.noMedia;
+    it('should use fake service if useHeadsets and only handling autoAnswer calls', () => {
+      proxyService['sdk']._mediaHandling = MediaHandling.autoAnswerOnly;
       const spy = jest.spyOn(proxyService, 'updateAudioInputDevice');
 
       proxyService.setUseHeadsets(true);

--- a/test/unit/headset/headset.test.ts
+++ b/test/unit/headset/headset.test.ts
@@ -816,6 +816,27 @@ describe('HeadsetProxyService', () => {
       expect(proxyService['orchestrationState']).toBe('hasControls');
     });
 
+    it('should not take controls if a prioritized request is received during orchestration even if handling alerting leader media', async () => {
+      proxyService['sdk']._mediaHandling = MediaHandling.alertingLeaderMedia;
+      proxyService['orchestrationState'] = 'hasControls';
+
+      const request: HeadsetControlsRequest = {
+        jsonrpc: '2.0',
+        method: 'headsetControlsRequest',
+        params: {
+          requestType: 'prioritized',
+        }
+      };
+      triggerMediaMessageEvent({ to: 'to', from: 'from', mediaMessage: request, fromMyClient: false, fromMyUser: true });
+
+      expect(proxyService['orchestrationState']).toBe('alternativeClient');
+      jest.advanceTimersByTime(1500);
+
+      expect(updateAudioSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled()
+      expect(proxyService['orchestrationState']).toBe('alternativeClient');
+    });
+
     it('should do nothing if persistent connection but no active session', async () => {
       expect(proxyService['orchestrationWaitTimer']).toBeFalsy();
 

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -84,7 +84,7 @@ describe('handlePropose()', () => {
     expect(superSpyHandlePropose).not.toHaveBeenCalled();
     expect(superSpyProceed).not.toHaveBeenCalled();
 
-    mockSdk._mediaHandling = MediaHandling.reducedMediaNoHeadsets;
+    mockSdk._mediaHandling = MediaHandling.reducedMedia;
     await handler.handlePropose(pendingSession);
     expect(spy).not.toHaveBeenCalled();
     expect(superSpyHandlePropose).not.toHaveBeenCalled();
@@ -116,7 +116,7 @@ describe('handlePropose()', () => {
     mockSdk._config.disableAutoAnswer = false;
     const pendingSession = createPendingSession(SessionTypes.softphone);
     pendingSession.autoAnswer = true;
-    mockSdk._mediaHandling = MediaHandling.reducedMediaNoHeadsets;
+    mockSdk._mediaHandling = MediaHandling.reducedMedia;
 
     await handler.handlePropose(pendingSession);
 

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -70,6 +70,56 @@ describe('shouldHandleSessionByJid()', () => {
 });
 
 describe('handlePropose()', () => {
+  it('should ignore the propose if mediaHandling is "autoAnswerOnly" and autoAnswer is false', async () => {
+    const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
+    const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();
+    const spy = jest.fn();
+    mockSdk.on('pendingSession', spy);
+    const pendingSession = createPendingSession(SessionTypes.softphone);
+    pendingSession.autoAnswer = false;
+    mockSdk._mediaHandling = MediaHandling.autoAnswerOnly;
+
+    await handler.handlePropose(pendingSession);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(superSpyHandlePropose).not.toHaveBeenCalled();
+    expect(superSpyProceed).not.toHaveBeenCalled();
+  });
+
+  it('should not autoAnswer if mediaHandling is "autoAnswerOnly", autoAnswer is true, but disableAutoAnswer is configured', async () => {
+    const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
+    const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();
+    const spy = jest.fn();
+    mockSdk.on('pendingSession', spy);
+    mockSdk._config.disableAutoAnswer = true;
+    const pendingSession = createPendingSession(SessionTypes.softphone);
+    pendingSession.autoAnswer = true;
+    mockSdk._mediaHandling = MediaHandling.autoAnswerOnly;
+
+    await handler.handlePropose(pendingSession);
+
+    expect(spy).toHaveBeenCalled();
+    expect(superSpyHandlePropose).toHaveBeenCalled();
+    expect(superSpyProceed).not.toHaveBeenCalled();
+  });
+
+  it('should emit pending session and proceed immediately if mediaHandling is "autoAnswerOnly", autoAnswer is true, and disableAutoAnswer is not configured', async () => {
+    const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
+    const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();
+    const spy = jest.fn();
+    mockSdk.on('pendingSession', spy);
+    mockSdk._config.disableAutoAnswer = false;
+    const pendingSession = createPendingSession(SessionTypes.softphone);
+    pendingSession.autoAnswer = true;
+    mockSdk._mediaHandling = MediaHandling.autoAnswerOnly;
+
+    await handler.handlePropose(pendingSession);
+
+    expect(spy).toHaveBeenCalled();
+    expect(superSpyHandlePropose).toHaveBeenCalled();
+    expect(superSpyProceed).toHaveBeenCalled();
+  });
+
   it('should emit pending session and proceed immediately if autoAnswer', async () => {
     const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
     const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();
@@ -86,21 +136,6 @@ describe('handlePropose()', () => {
     expect(spy).toHaveBeenCalled();
     expect(superSpyHandlePropose).toHaveBeenCalled();
     expect(superSpyProceed).toHaveBeenCalled();
-  });
-
-  it('should ignore the propose if mediaHandling is set to "noMedia"', async () => {
-    const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
-    const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();
-    const spy = jest.fn();
-    mockSdk.on('pendingSession', spy);
-    const pendingSession = createPendingSession(SessionTypes.softphone);
-    mockSdk._mediaHandling = MediaHandling.noMedia;
-
-    await handler.handlePropose(pendingSession);
-
-    expect(spy).not.toHaveBeenCalled();
-    expect(superSpyHandlePropose).not.toHaveBeenCalled();
-    expect(superSpyProceed).not.toHaveBeenCalled();
   });
 
   it('should not auto answer if pending session is not autoAnswer', async () => {

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -28,7 +28,8 @@ import {
   SdkErrorTypes,
   IPendingSession,
   JingleReasons,
-  ISessionMuteRequest
+  ISessionMuteRequest,
+  MediaHandling
 } from '../../../src';
 import { SessionManager } from '../../../src/sessions/session-manager';
 import BaseSessionHandler from '../../../src/sessions/base-session-handler';
@@ -85,6 +86,21 @@ describe('handlePropose()', () => {
     expect(spy).toHaveBeenCalled();
     expect(superSpyHandlePropose).toHaveBeenCalled();
     expect(superSpyProceed).toHaveBeenCalled();
+  });
+
+  it('should ignore the propose if mediaHandling is set to "noMedia"', async () => {
+    const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
+    const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();
+    const spy = jest.fn();
+    mockSdk.on('pendingSession', spy);
+    const pendingSession = createPendingSession(SessionTypes.softphone);
+    mockSdk._mediaHandling = MediaHandling.noMedia;
+
+    await handler.handlePropose(pendingSession);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(superSpyHandlePropose).not.toHaveBeenCalled();
+    expect(superSpyProceed).not.toHaveBeenCalled();
   });
 
   it('should not auto answer if pending session is not autoAnswer', async () => {

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -70,23 +70,28 @@ describe('shouldHandleSessionByJid()', () => {
 });
 
 describe('handlePropose()', () => {
-  it('should ignore the propose if mediaHandling is "autoAnswerOnly" and autoAnswer is false', async () => {
+  it('should ignore the propose if mediaHandling is a reducedMedia variant and autoAnswer is false', async () => {
     const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
     const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();
     const spy = jest.fn();
     mockSdk.on('pendingSession', spy);
     const pendingSession = createPendingSession(SessionTypes.softphone);
     pendingSession.autoAnswer = false;
-    mockSdk._mediaHandling = MediaHandling.autoAnswerOnly;
 
+    mockSdk._mediaHandling = MediaHandling.reducedMediaHeadsets;
     await handler.handlePropose(pendingSession);
+    expect(spy).not.toHaveBeenCalled();
+    expect(superSpyHandlePropose).not.toHaveBeenCalled();
+    expect(superSpyProceed).not.toHaveBeenCalled();
 
+    mockSdk._mediaHandling = MediaHandling.reducedMediaNoHeadsets;
+    await handler.handlePropose(pendingSession);
     expect(spy).not.toHaveBeenCalled();
     expect(superSpyHandlePropose).not.toHaveBeenCalled();
     expect(superSpyProceed).not.toHaveBeenCalled();
   });
 
-  it('should not autoAnswer if mediaHandling is "autoAnswerOnly", autoAnswer is true, but disableAutoAnswer is configured', async () => {
+  it('should not autoAnswer if mediaHandling is reducedMedia, autoAnswer is true, but disableAutoAnswer is configured', async () => {
     const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
     const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();
     const spy = jest.fn();
@@ -94,7 +99,7 @@ describe('handlePropose()', () => {
     mockSdk._config.disableAutoAnswer = true;
     const pendingSession = createPendingSession(SessionTypes.softphone);
     pendingSession.autoAnswer = true;
-    mockSdk._mediaHandling = MediaHandling.autoAnswerOnly;
+    mockSdk._mediaHandling = MediaHandling.reducedMediaHeadsets;
 
     await handler.handlePropose(pendingSession);
 
@@ -103,7 +108,7 @@ describe('handlePropose()', () => {
     expect(superSpyProceed).not.toHaveBeenCalled();
   });
 
-  it('should emit pending session and proceed immediately if mediaHandling is "autoAnswerOnly", autoAnswer is true, and disableAutoAnswer is not configured', async () => {
+  it('should emit pending session and proceed immediately if mediaHandling is reducedMedia, autoAnswer is true, and disableAutoAnswer is not configured', async () => {
     const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
     const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();
     const spy = jest.fn();
@@ -111,7 +116,7 @@ describe('handlePropose()', () => {
     mockSdk._config.disableAutoAnswer = false;
     const pendingSession = createPendingSession(SessionTypes.softphone);
     pendingSession.autoAnswer = true;
-    mockSdk._mediaHandling = MediaHandling.autoAnswerOnly;
+    mockSdk._mediaHandling = MediaHandling.reducedMediaNoHeadsets;
 
     await handler.handlePropose(pendingSession);
 


### PR DESCRIPTION
The basic idea is that as different clients become the alerting leader, the other clients should not be handling media (such as eager persistent connections) or headsets. But we still want them to be capable of outbound calls. However, the initial clients using alerting leader will be using their streaming-client connections as the alerting leader, so the SDK cannot simply react to alerting leader changes on its own. This PR allows clients to tell the SDK how it should handle media (and adjusts headset orchestration slightly so an alerting leader takes priority).

### MERGE CHECKLIST

- [x] Tests have been updated, added, or removed and the testing matrix has passed.
- [x] Documentation has been updated or added.
- [x] Changelog has been updated with ticket or issue number, link to the ticket, and a description of the changes.
- [x] Branch has been built in the BitBucket wrapper repository.
- [x] Pull request title is formatted as `[STREAM-<ticket number>] - <description of changes>` or `[<issue number>] - <description of changes>`.
- [ ] Release pull requests include someone from the PureScale team for approval.
  - [ ] Build release branch in wrapper repository and make sure it is tagged with `next` on npm.

