### PR TITLE
[STREAM-1568] Pass through `alertableInteractionTypes` to streaming-client

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v13.1.0...HEAD)
 ### Added
 * [STREAM-151](https://inindca.atlassian.net/browse/STREAM-151) - Send media statistics to the server. Aggregates stats, calculates a MOS score and pushes at regular intervals.
+* [STREAM-1568](https://inindca.atlassian.net/browse/STREAM-1568) - Add passthrough for `alertableInteractionTypes` to streaming-client.
 
 ### Changed
 * [STREAM-1487](https://inindca.atlassian.net/browse/STREAM-1487) - Update `axios` to v1.15.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "browserama": "^3.2.2",
         "core-js": "^3.37.1",
         "genesys-cloud-client-logger": "^4.2.17",
-        "genesys-cloud-streaming-client": "^19.5.0",
+        "genesys-cloud-streaming-client": "^19.7.0",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.18.1",
         "process-fast": "^1.0.0",
@@ -6348,11 +6348,13 @@
       }
     },
     "node_modules/genesys-cloud-streaming-client": {
-      "version": "19.5.0",
+      "version": "19.7.0",
+      "resolved": "https://registry.npmjs.org/genesys-cloud-streaming-client/-/genesys-cloud-streaming-client-19.7.0.tgz",
+      "integrity": "sha512-OgFIbe8dePI5HXQVO6/KkLkxBWKFL7iqq9uxkmUqZuNIaV0AzyoP3B0X+Nmko4JrQGPAfXtaFLsxV3I7LfOAIg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.10.4",
-        "axios": "^1.12.0",
+        "axios": "^1.15.0",
         "backoff-web": "^1.0.1",
         "browserama": "^3.2.0",
         "core-js": "^3.6.5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "browserama": "^3.2.2",
     "core-js": "^3.37.1",
     "genesys-cloud-client-logger": "^4.2.17",
-    "genesys-cloud-streaming-client": "^19.5.0",
+    "genesys-cloud-streaming-client": "^19.7.0",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.18.1",
     "process-fast": "^1.0.0",

--- a/src/client-private.ts
+++ b/src/client-private.ts
@@ -59,6 +59,7 @@ export async function setupStreamingClient (this: GenesysCloudWebrtcSdk): Promis
   }
 
   connectionOptions.useServerSidePings = !!this._config.useServerSidePings;
+  connectionOptions.alertableInteractionTypes = this._config.alertableInteractionTypes;
 
   connectionOptions.logFormatters = this._config.logFormatters;
   this.logger.debug('Streaming client WebSocket connection options', connectionOptions);

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,5 +1,5 @@
 /* eslint-disable-line @typescript-eslint/no-explicit-any */
-import { ISessionInfo, IPendingSession, IMediaSession, TypedJsonRpcMessage } from 'genesys-cloud-streaming-client';
+import { ISessionInfo, IPendingSession, IMediaSession, TypedJsonRpcMessage, AlertableInteractionTypes } from 'genesys-cloud-streaming-client';
 import { JingleReason } from 'stanza/protocol';
 import { Constants } from 'stanza';
 import ILogger, { LogFormatterFn } from 'genesys-cloud-client-logger';
@@ -271,6 +271,11 @@ export interface ISdkFullConfig {
    * Optional: default `false`
    */
   reportStatistics?: boolean;
+
+  /**
+   * Genesys internal use only - non-Genesys apps that pass in `alertableInteractionTypes` may experience unexpected behavior
+   */
+  alertableInteractionTypes?: AlertableInteractionTypes[];
 
   /** defaults for various SDK functionality */
   defaults?: {

--- a/test/mock-apis.ts
+++ b/test/mock-apis.ts
@@ -169,6 +169,13 @@ export function mockGetOrgApi (params: MockSingleApiOptions): AxiosMockAdapter {
   return intercept.reply(200, MOCK_ORG);
 }
 
+// Mock the `users/me` request streaming-client uses to check network connectivity
+export function mockGetUserApiForStreamingClient (): AxiosMockAdapter {
+  const intercept = getAxiosAdapter().onGet(`${getDefaultHostUri()}/api/v2/users/me`);
+
+  return intercept.reply(200, MOCK_USER);
+}
+
 export function mockGetUserApi (params: MockSingleApiOptions): AxiosMockAdapter {
   const intercept = getAxiosAdapter().onGet(`${getDefaultHostUri()}/api/v2/users/me?expand=station`);
 
@@ -252,6 +259,7 @@ function mockApis (options: MockApiOptions = {}): MockApiReturns {
     //   .reply(200, { id: 'someguestchangeid' });
 
   } else {
+    mockGetUserApiForStreamingClient();
     mockGetOrgApi({ shouldFail: failOrg });
     mockGetUserApi({ shouldFail: failUser });
     mockGetChannelApi({ });


### PR DESCRIPTION
This is currently for the sake of automated testing, not intended as full support of alerting leader functionality via the SDK.

### MERGE CHECKLIST

- [x] Tests have been updated, added, or removed and the testing matrix has passed.
- [x] Documentation has been updated or added.
- [x] Changelog has been updated with ticket or issue number, link to the ticket, and a description of the changes.
- [x] Branch has been built in the BitBucket wrapper repository.
- [x] Pull request title is formatted as `[STREAM-<ticket number>] - <description of changes>` or `[<issue number>] - <description of changes>`.
- [ ] Release pull requests include someone from the PureScale team for approval.
  - [ ] Build release branch in wrapper repository and make sure it is tagged with `next` on npm.

