### PR TITLE
[STREAM-1589] Drop `mediaResourceId` and simply rely on `sessionId` for media statistics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * [STREAM-1487](https://inindca.atlassian.net/browse/STREAM-1487) - Update `axios` to v1.15.2
+* [STREAM-1589](https://inindca.atlassian.net/browse/STREAM-1589) - Drop `mediaResourceId` and simply rely on `sessionId` for media statistics
 
 ### Fixed
 * [STREAM-1322](https://inindca.atlassian.net/browse/STREAM-1322) - Fix `logLevel` not being passed to the internal streaming-client, causing it to always default to `'info'` regardless of the SDK's configured log level.

--- a/src/stats-aggregator.ts
+++ b/src/stats-aggregator.ts
@@ -10,7 +10,6 @@ interface ISentStats {
 }
 
 export class StatsAggregator {
-  private mediaResourceId: string;
   private statsGatherer?: StatsGatherer;
 
   private setBaseline = false;
@@ -24,8 +23,6 @@ export class StatsAggregator {
   private boundStatsHandler?: (stats: StatsEvent) => void;
 
   constructor(private session: IExtendedMediaSession, private sdk: GenesysCloudWebrtSdk) {
-    this.mediaResourceId = uuidv4();
-
     if (this.shouldGatherImmediately(session)) {
       this.startGatheringStats();
     }
@@ -231,7 +228,6 @@ export class StatsAggregator {
           sessionId: this.session.id,
           conversationId,
           communicationId,
-          mediaResourceId: this.mediaResourceId,
           stats: statsData
         }
       }

--- a/test/unit/stats-aggregator.test.ts
+++ b/test/unit/stats-aggregator.test.ts
@@ -421,7 +421,6 @@ describe('StatsAggregator', () => {
       expect(iqArg.genesysWebrtc.params.conversationId).toBe(mockSession.conversationId);
       expect(iqArg.genesysWebrtc.params.sessionId).toBe(mockSession.id);
       expect(iqArg.genesysWebrtc.params.communicationId).toBe('testCall');
-      expect(iqArg.genesysWebrtc.params.mediaResourceId).toBeTruthy();
       expect(iqArg.genesysWebrtc.params.stats).toBeDefined();
     });
 


### PR DESCRIPTION
### MERGE CHECKLIST

- [x] Tests have been updated, added, or removed and the testing matrix has passed.
- [x] Documentation has been updated or added.
- [x] Changelog has been updated with ticket or issue number, link to the ticket, and a description of the changes.
- [ ] Branch has been built in the BitBucket wrapper repository.
- [x] Pull request title is formatted as `[STREAM-<ticket number>] - <description of changes>` or `[<issue number>] - <description of changes>`.
- [ ] Release pull requests include someone from the PureScale team for approval.
  - [ ] Build release branch in wrapper repository and make sure it is tagged with `next` on npm.

