### PR TITLE
[STREAM-1789] - Terminate zombie persistent connection sessions that never fully established

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * [STREAM-1800](https://inindca.atlassian.net/browse/STREAM-1394) - Dependency bump for `softphone-vendor-headsets` to fix a recent issue with the vendor Yealink
 * [STREAM-1241](https://inindca.atlassian.net/browse/STREAM-1394) - Prevent redundant pendingSession for already-connected call
+* [STREAM-1789](https://inindca.atlassian.net/browse/STREAM-1789) - Terminate persistent connection sessions that never fully established (ICE never completed) when the pending call is canceled, preventing zombie sessions with stale conversationIds from being reused by future calls
 
 # [v14.1.0](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v14.0.0...v14.1.0)
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genesys-cloud-webrtc-sdk",
-  "version": "14.1.0",
+  "version": "14.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genesys-cloud-webrtc-sdk",
-      "version": "14.1.0",
+      "version": "14.1.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.6",
@@ -68,7 +68,7 @@
         "typescript": "^5.9.3",
         "webpack": "^5.105.0",
         "webpack-cli": "^5.1.4",
-        "ws": "^8.17.1"
+        "ws": "^8.21.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.9.5"
@@ -2783,9 +2783,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
-      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
+      "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
       "cpu": [
         "x64"
       ],
@@ -3875,9 +3875,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -10422,9 +10422,9 @@
       "license": "ISC"
     },
     "node_modules/softphone-vendor-headsets": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-3.0.2.tgz",
-      "integrity": "sha512-ufuU5z1GvlBioineyhUYQ6i21Kp2VcieV7STJk6aBUyFHuDPExzWFDZqYKOcXrHvg+IqrzJfxelo6S8QRPi5bA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/softphone-vendor-headsets/-/softphone-vendor-headsets-3.0.3.tgz",
+      "integrity": "sha512-VP62I6JinjTjQ59/Wc07x802CTtxj3BRPvNeye8XJ5O3uIn09N+kpsMOcGltY9R4t8GXkJulQeEBuol/0kRmvQ==",
       "license": "MIT",
       "dependencies": {
         "@gnaudio/jabra-js": "^4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genesys-cloud-webrtc-sdk",
-  "version": "14.1.1",
+  "version": "14.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genesys-cloud-webrtc-sdk",
-      "version": "14.1.1",
+      "version": "14.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genesys-cloud-webrtc-sdk",
-  "version": "14.1.0",
+  "version": "14.1.1",
   "description": "client for the interfacing with Genesys Cloud WebRTC",
   "repository": "https://github.com/mypurecloud/genesys-cloud-webrtc-sdk",
   "license": "MIT",
@@ -114,7 +114,7 @@
     "typescript": "^5.9.3",
     "webpack": "^5.105.0",
     "webpack-cli": "^5.1.4",
-    "ws": "^8.17.1"
+    "ws": "^8.21.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.9.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genesys-cloud-webrtc-sdk",
-  "version": "14.1.1",
+  "version": "14.1.0",
   "description": "client for the interfacing with Genesys Cloud WebRTC",
   "repository": "https://github.com/mypurecloud/genesys-cloud-webrtc-sdk",
   "license": "MIT",

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -371,13 +371,6 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
           }
           eventToEmit = 'added';
         }
-
-        /* notify the backend of the client's IP address when the call reaches 'connected' state.
-           This is checked separately because the 'added' block above may not execute for
-           dialing -> connected transitions (since dialing is already a "connected" state). */
-        if (callState.state === CommunicationStates.connected && previousCallState?.state !== CommunicationStates.connected && session) {
-          this.notifyClientMetadata(conversationId, callState.id);
-        }
       } else if (this.isEndedState(callState)) {
         if (this.isPendingState(previousCallState) && !isOutbound) {
           this.sdk.headset.rejectIncomingCall(conversationId);
@@ -392,6 +385,19 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
         if (this.isPendingState(previousCallState)) {
           if (session && session === this.activeSession) {
             this.sessionManager.onCancelPendingSession(session.id, conversationId);
+
+            // If the session never fully established (e.g. SDP answer was sent but ICE never completed),
+            // terminate it so it doesn't linger as a zombie that future calls try to reuse.
+            if (session.peerConnection.connectionState !== 'connected') {
+              this.log('warn', 'terminating session that never fully established after pending session was canceled', {
+                sessionId: session.id,
+                conversationId,
+                connectionState: session.peerConnection.connectionState
+              });
+              this.forceEndSession(session, JingleReasons.gone).catch((err) => {
+                this.log('error', 'failed to terminate zombie session', { sessionId: session.id, conversationId, error: err });
+              });
+            }
           }
           delete this.conversations[conversationId];
         } else if (previousCallState) {
@@ -696,9 +702,6 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
         session
       });
       this.log('info', 'Media started', { conversationId: session.conversationId, sessionId: session.id, sessionType: session.sessionType });
-    }
-    if (this.sdk.audioProcessor) {
-      stream = await this.sdk.audioProcessor.process(stream);
     }
     await this.addMediaToSession(session, stream);
     session._outboundStream = stream;
@@ -1016,21 +1019,6 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
 
   private isEndedState (call: ICallStateFromParticipant): boolean {
     return call?.state === CommunicationStates.disconnected || call?.state === CommunicationStates.terminated;
-  }
-
-  /**
-   * Notify the backend that a call has connected for this client.
-   * The server captures the client's IP address from the HTTP request.
-   * This is fire-and-forget — errors are logged but do not affect call handling.
-   */
-  private notifyClientMetadata (conversationId: string, communicationId: string): void {
-    const path = `/conversations/calls/${conversationId}/communications/${communicationId}/metadata`;
-    this.log('info', 'notifying client metadata for connected call', { conversationId, communicationId });
-
-    requestApi.call(this.sdk, path, { method: 'post' })
-      .catch(err => {
-        this.log('warn', 'failed to notify client metadata', { conversationId, communicationId, error: err?.message });
-      });
   }
 }
 

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -371,6 +371,13 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
           }
           eventToEmit = 'added';
         }
+
+        /* notify the backend of the client's IP address when the call reaches 'connected' state.
+           This is checked separately because the 'added' block above may not execute for
+           dialing -> connected transitions (since dialing is already a "connected" state). */
+        if (callState.state === CommunicationStates.connected && previousCallState?.state !== CommunicationStates.connected && session) {
+          this.notifyClientMetadata(conversationId, callState.id);
+        }
       } else if (this.isEndedState(callState)) {
         if (this.isPendingState(previousCallState) && !isOutbound) {
           this.sdk.headset.rejectIncomingCall(conversationId);
@@ -703,6 +710,9 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
       });
       this.log('info', 'Media started', { conversationId: session.conversationId, sessionId: session.id, sessionType: session.sessionType });
     }
+    if (this.sdk.audioProcessor) {
+      stream = await this.sdk.audioProcessor.process(stream);
+    }
     await this.addMediaToSession(session, stream);
     session._outboundStream = stream;
 
@@ -1019,6 +1029,21 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
 
   private isEndedState (call: ICallStateFromParticipant): boolean {
     return call?.state === CommunicationStates.disconnected || call?.state === CommunicationStates.terminated;
+  }
+
+  /**
+   * Notify the backend that a call has connected for this client.
+   * The server captures the client's IP address from the HTTP request.
+   * This is fire-and-forget — errors are logged but do not affect call handling.
+   */
+  private notifyClientMetadata (conversationId: string, communicationId: string): void {
+    const path = `/conversations/calls/${conversationId}/communications/${communicationId}/metadata`;
+    this.log('info', 'notifying client metadata for connected call', { conversationId, communicationId });
+
+    requestApi.call(this.sdk, path, { method: 'post' })
+      .catch(err => {
+        this.log('warn', 'failed to notify client metadata', { conversationId, communicationId, error: err?.message });
+      });
   }
 }
 

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -401,7 +401,7 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
                 conversationId,
                 connectionState: session.peerConnection.connectionState
               });
-              this.forceEndSession(session, JingleReasons.gone).catch((err) => {
+              this.forceEndSession(session, JingleReasons.timeout).catch((err) => {
                 this.log('error', 'failed to terminate zombie session', { sessionId: session.id, conversationId, error: err });
               });
             }

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -532,6 +532,37 @@ describe('acceptSession()', () => {
     expect(attachSpy).toHaveBeenCalledWith(mockSdk, expect.anything(), volume, element, ids);
   });
 
+  it('should run the provided stream through the audio processor if configured', async () => {
+    jest.spyOn(BaseSessionHandler.prototype, 'acceptSession');
+    jest.spyOn(mediaUtils, 'attachAudioMedia').mockImplementation();
+    const addMediaSpy = jest.spyOn(handler, 'addMediaToSession').mockImplementation();
+    jest.spyOn(mockSdk.media, 'startMedia');
+
+    const mockOutgoingStream = new MockStream({ audio: true });
+    const processedStream = new MockStream({ audio: true });
+    const processSpy = jest.fn().mockResolvedValue(processedStream);
+    (mockSdk as any).audioProcessor = { process: processSpy };
+
+    const session: any = new MockSession();
+    session.peerConnection.getReceivers = jest.fn().mockReturnValue([
+      { track: { kind: 'audio' } }
+    ]);
+    session.streams = [new MockStream({ audio: true })];
+
+    const params: IAcceptSessionRequest = {
+      conversationId: session.conversationId,
+      audioElement: {} as any,
+      mediaStream: mockOutgoingStream as any
+    };
+
+    await handler.acceptSession(session, params);
+
+    expect(processSpy).toHaveBeenCalledWith(mockOutgoingStream);
+    /* the processed stream is what flows to the session */
+    expect(addMediaSpy).toHaveBeenCalledWith(session, processedStream);
+    expect(session._outboundStream).toBe(processedStream);
+  });
+
   it('should add media using default stream and element then accept session', async () => {
     const acceptSpy = jest.spyOn(BaseSessionHandler.prototype, 'acceptSession');
     const attachSpy = jest.spyOn(mediaUtils, 'attachAudioMedia').mockImplementation();
@@ -1145,12 +1176,15 @@ describe('handleSoftphoneConversationUpdate()', () => {
   const userJid = 'martians-like-to-talk-too@mars.com';
   let emitConversationEventSpy: jest.SpyInstance;
   let sdkEmitSpy: jest.SpyInstance;
+  let notifyClientMetadataSpy: jest.SpyInstance;
 
   beforeEach(() => {
     mockSdk._personDetails = { id: userId, chat: { jabberId: userJid } } as IPersonDetails;
     emitConversationEventSpy = jest.spyOn(handler, 'emitConversationEvent')
       .mockImplementation();
     sdkEmitSpy = jest.spyOn(mockSdk, 'emit').mockImplementation();
+    notifyClientMetadataSpy = jest.spyOn(handler as any, 'notifyClientMetadata')
+      .mockImplementation();
   });
 
   describe('headset functionality', () => {
@@ -1742,6 +1776,195 @@ describe('handleSoftphoneConversationUpdate()', () => {
       session
     );
     expect(handler.conversations[update.id]).toBeTruthy();
+  });
+
+  describe('notifyClientMetadata', () => {
+    let requestApiSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      notifyClientMetadataSpy.mockRestore();
+      requestApiSpy = jest.spyOn(utils, 'requestApi').mockResolvedValue(null);
+    });
+
+    afterEach(() => {
+      requestApiSpy.mockRestore();
+    });
+
+    it('should notify client metadata when call transitions from alerting to connected (inbound)', () => {
+      const { update, participant, callState, session, previousUpdate } = generateUpdate({
+        callState: CommunicationStates.connected,
+        previousCallState: { state: CommunicationStates.alerting }
+      });
+
+      callState.direction = 'inbound';
+      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+      handler.activeSession = session;
+
+      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+      expect(requestApiSpy).toHaveBeenCalledWith(
+        `/conversations/calls/${update.id}/communications/${callState.id}/metadata`,
+        { method: 'post' }
+      );
+    });
+
+    it('should notify client metadata when call transitions from contacting to connected (outbound)', () => {
+      const { update, participant, callState, session, previousUpdate } = generateUpdate({
+        callState: CommunicationStates.connected,
+        previousCallState: { state: CommunicationStates.contacting }
+      });
+
+      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+
+      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+      expect(requestApiSpy).toHaveBeenCalledWith(
+        `/conversations/calls/${update.id}/communications/${callState.id}/metadata`,
+        { method: 'post' }
+      );
+    });
+
+    it('should notify client metadata when call transitions from dialing to connected (outbound)', () => {
+      const { update, participant, callState, session, previousUpdate } = generateUpdate({
+        callState: CommunicationStates.connected,
+        previousCallState: { state: CommunicationStates.dialing }
+      });
+
+      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+
+      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+      expect(requestApiSpy).toHaveBeenCalledWith(
+        `/conversations/calls/${update.id}/communications/${callState.id}/metadata`,
+        { method: 'post' }
+      );
+    });
+
+    it('should notify client metadata for persistent connection (new conversation on existing session)', () => {
+      const session = new MockSession() as any as IExtendedMediaSession;
+      session.conversationId = 'old-conversation-id';
+      (session as any)._emittedSessionStarteds = {};
+
+      const callState = {
+        id: 'call-id',
+        state: CommunicationStates.connected,
+        muted: false,
+        confined: false,
+        held: false,
+        direction: 'inbound' as const,
+        provider: 'provider'
+      } as ICallStateFromParticipant;
+
+      const newConversationId = 'new-conversation-id';
+      const participant = {
+        id: 'participants-1',
+        purpose: 'agent',
+        userId,
+        calls: [callState],
+        videos: []
+      } as IConversationParticipantFromEvent;
+
+      const update = new ConversationUpdate({
+        id: newConversationId,
+        participants: [participant]
+      });
+
+      // Set up as if we had a previous alerting state for this conversation
+      const previousCallState = { ...callState, state: CommunicationStates.alerting };
+      const previousParticipant = { ...participant, calls: [previousCallState] };
+      const previousUpdate = new ConversationUpdate({
+        id: newConversationId,
+        participants: [previousParticipant]
+      });
+
+      handler.conversations[newConversationId] = { conversationUpdate: previousUpdate } as any;
+      handler.activeSession = session;
+
+      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+      expect(requestApiSpy).toHaveBeenCalledWith(
+        `/conversations/calls/${newConversationId}/communications/${callState.id}/metadata`,
+        { method: 'post' }
+      );
+    });
+
+    it('should NOT notify client metadata when call transitions to dialing (not yet connected)', () => {
+      const { update, participant, callState, session, previousUpdate } = generateUpdate({
+        callState: CommunicationStates.dialing,
+        previousCallState: { state: CommunicationStates.contacting }
+      });
+
+      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+      handler.activeSession = session;
+
+      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+      expect(requestApiSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('metadata'),
+        expect.anything()
+      );
+    });
+
+    it('should NOT notify client metadata when no session exists (another client handled it)', () => {
+      const { update, participant, callState, previousUpdate } = generateUpdate({
+        callState: CommunicationStates.connected,
+        previousCallState: { state: CommunicationStates.contacting }
+      });
+
+      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+
+      handler.handleSoftphoneConversationUpdate(update, participant, callState, undefined);
+
+      expect(requestApiSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('metadata'),
+        expect.anything()
+      );
+    });
+
+    it('should NOT notify client metadata when state is already connected (duplicate update)', () => {
+      const { update, participant, callState, session, previousUpdate } = generateUpdate({
+        callState: CommunicationStates.connected,
+        previousCallState: { state: CommunicationStates.connected }
+      });
+
+      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+
+      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+      expect(requestApiSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('metadata'),
+        expect.anything()
+      );
+    });
+
+    it('should not block call handling if notifyClientMetadata fails', async () => {
+      requestApiSpy.mockRejectedValue(new Error('network error'));
+
+      const { update, participant, callState, session, previousUpdate } = generateUpdate({
+        callState: CommunicationStates.connected,
+        previousCallState: { state: CommunicationStates.alerting }
+      });
+
+      callState.direction = 'inbound';
+      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+      handler.activeSession = session;
+
+      // should not throw
+      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+      await flushPromises();
+
+      expect(requestApiSpy).toHaveBeenCalledWith(
+        `/conversations/calls/${update.id}/communications/${callState.id}/metadata`,
+        { method: 'post' }
+      );
+      // The error should be logged but not propagated
+      expect(mockSdk.logger.warn).toHaveBeenCalledWith(
+        'failed to notify client metadata',
+        expect.objectContaining({ conversationId: update.id, communicationId: callState.id }),
+        undefined
+      );
+    });
   });
 });
 

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -532,37 +532,6 @@ describe('acceptSession()', () => {
     expect(attachSpy).toHaveBeenCalledWith(mockSdk, expect.anything(), volume, element, ids);
   });
 
-  it('should run the provided stream through the audio processor if configured', async () => {
-    jest.spyOn(BaseSessionHandler.prototype, 'acceptSession');
-    jest.spyOn(mediaUtils, 'attachAudioMedia').mockImplementation();
-    const addMediaSpy = jest.spyOn(handler, 'addMediaToSession').mockImplementation();
-    jest.spyOn(mockSdk.media, 'startMedia');
-
-    const mockOutgoingStream = new MockStream({ audio: true });
-    const processedStream = new MockStream({ audio: true });
-    const processSpy = jest.fn().mockResolvedValue(processedStream);
-    (mockSdk as any).audioProcessor = { process: processSpy };
-
-    const session: any = new MockSession();
-    session.peerConnection.getReceivers = jest.fn().mockReturnValue([
-      { track: { kind: 'audio' } }
-    ]);
-    session.streams = [new MockStream({ audio: true })];
-
-    const params: IAcceptSessionRequest = {
-      conversationId: session.conversationId,
-      audioElement: {} as any,
-      mediaStream: mockOutgoingStream as any
-    };
-
-    await handler.acceptSession(session, params);
-
-    expect(processSpy).toHaveBeenCalledWith(mockOutgoingStream);
-    /* the processed stream is what flows to the session */
-    expect(addMediaSpy).toHaveBeenCalledWith(session, processedStream);
-    expect(session._outboundStream).toBe(processedStream);
-  });
-
   it('should add media using default stream and element then accept session', async () => {
     const acceptSpy = jest.spyOn(BaseSessionHandler.prototype, 'acceptSession');
     const attachSpy = jest.spyOn(mediaUtils, 'attachAudioMedia').mockImplementation();
@@ -1176,15 +1145,12 @@ describe('handleSoftphoneConversationUpdate()', () => {
   const userJid = 'martians-like-to-talk-too@mars.com';
   let emitConversationEventSpy: jest.SpyInstance;
   let sdkEmitSpy: jest.SpyInstance;
-  let notifyClientMetadataSpy: jest.SpyInstance;
 
   beforeEach(() => {
     mockSdk._personDetails = { id: userId, chat: { jabberId: userJid } } as IPersonDetails;
     emitConversationEventSpy = jest.spyOn(handler, 'emitConversationEvent')
       .mockImplementation();
     sdkEmitSpy = jest.spyOn(mockSdk, 'emit').mockImplementation();
-    notifyClientMetadataSpy = jest.spyOn(handler as any, 'notifyClientMetadata')
-      .mockImplementation();
   });
 
   describe('headset functionality', () => {
@@ -1579,6 +1545,78 @@ describe('handleSoftphoneConversationUpdate()', () => {
     expect(sdkEmitSpy).not.toHaveBeenCalled();
   });
 
+  it('should terminate session that never fully established when pending session is canceled', async () => {
+    const { update, participant, callState, session, previousUpdate } = generateUpdate({
+      callState: CommunicationStates.disconnected,
+      previousCallState: { state: CommunicationStates.alerting }
+    });
+    const onCancelPendingSessionSpy = jest.spyOn(mockSessionManager, 'onCancelPendingSession').mockImplementation();
+    const forceEndSessionSpy = jest.spyOn(handler, 'forceEndSession').mockResolvedValue(undefined);
+
+    // Simulate a session where SDP answer was sent but ICE never completed
+    (session.peerConnection as any).connectionState = 'new';
+
+    handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+    handler.activeSession = session;
+
+    handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+    await flushPromises();
+
+    expect(onCancelPendingSessionSpy).toHaveBeenCalledWith(session.id, update.id);
+    expect(forceEndSessionSpy).toHaveBeenCalledWith(session, 'gone');
+    expect(handler.conversations[update.id]).toBeFalsy();
+  });
+
+  it('should not terminate session if it is already connected when pending session is canceled', async () => {
+    const { update, participant, callState, session, previousUpdate } = generateUpdate({
+      callState: CommunicationStates.disconnected,
+      previousCallState: { state: CommunicationStates.alerting }
+    });
+    const onCancelPendingSessionSpy = jest.spyOn(mockSessionManager, 'onCancelPendingSession').mockImplementation();
+    const forceEndSessionSpy = jest.spyOn(handler, 'forceEndSession').mockResolvedValue(undefined);
+
+    // Session is already fully connected (persistent connection is healthy)
+    (session.peerConnection as any).connectionState = 'connected';
+
+    handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+    handler.activeSession = session;
+
+    handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+    await flushPromises();
+
+    expect(onCancelPendingSessionSpy).toHaveBeenCalledWith(session.id, update.id);
+    expect(forceEndSessionSpy).not.toHaveBeenCalled();
+    expect(handler.conversations[update.id]).toBeFalsy();
+  });
+
+  it('should not throw if forceEndSession rejects when terminating zombie session', async () => {
+    const { update, participant, callState, session, previousUpdate } = generateUpdate({
+      callState: CommunicationStates.disconnected,
+      previousCallState: { state: CommunicationStates.alerting }
+    });
+    jest.spyOn(mockSessionManager, 'onCancelPendingSession').mockImplementation();
+    const forceEndSessionSpy = jest.spyOn(handler, 'forceEndSession').mockRejectedValue(new Error('terminate failed'));
+    const logSpy = jest.spyOn(handler, 'log' as any);
+
+    (session.peerConnection as any).connectionState = 'connecting';
+
+    handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+    handler.activeSession = session;
+
+    handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+    await flushPromises();
+
+    expect(forceEndSessionSpy).toHaveBeenCalledWith(session, 'gone');
+    expect(logSpy).toHaveBeenCalledWith(
+      'error',
+      'failed to terminate zombie session',
+      expect.objectContaining({ sessionId: session.id, conversationId: update.id })
+    );
+  });
+
   it('should delete conversationState, not emit an event, and not cancelPendingSession if session does not match active session', async () => {
     const { update, participant, callState, session, previousUpdate } = generateUpdate({
       callState: CommunicationStates.disconnected,
@@ -1704,195 +1742,6 @@ describe('handleSoftphoneConversationUpdate()', () => {
       session
     );
     expect(handler.conversations[update.id]).toBeTruthy();
-  });
-
-  describe('notifyClientMetadata', () => {
-    let requestApiSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      notifyClientMetadataSpy.mockRestore();
-      requestApiSpy = jest.spyOn(utils, 'requestApi').mockResolvedValue(null);
-    });
-
-    afterEach(() => {
-      requestApiSpy.mockRestore();
-    });
-
-    it('should notify client metadata when call transitions from alerting to connected (inbound)', () => {
-      const { update, participant, callState, session, previousUpdate } = generateUpdate({
-        callState: CommunicationStates.connected,
-        previousCallState: { state: CommunicationStates.alerting }
-      });
-
-      callState.direction = 'inbound';
-      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
-      handler.activeSession = session;
-
-      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
-
-      expect(requestApiSpy).toHaveBeenCalledWith(
-        `/conversations/calls/${update.id}/communications/${callState.id}/metadata`,
-        { method: 'post' }
-      );
-    });
-
-    it('should notify client metadata when call transitions from contacting to connected (outbound)', () => {
-      const { update, participant, callState, session, previousUpdate } = generateUpdate({
-        callState: CommunicationStates.connected,
-        previousCallState: { state: CommunicationStates.contacting }
-      });
-
-      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
-
-      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
-
-      expect(requestApiSpy).toHaveBeenCalledWith(
-        `/conversations/calls/${update.id}/communications/${callState.id}/metadata`,
-        { method: 'post' }
-      );
-    });
-
-    it('should notify client metadata when call transitions from dialing to connected (outbound)', () => {
-      const { update, participant, callState, session, previousUpdate } = generateUpdate({
-        callState: CommunicationStates.connected,
-        previousCallState: { state: CommunicationStates.dialing }
-      });
-
-      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
-
-      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
-
-      expect(requestApiSpy).toHaveBeenCalledWith(
-        `/conversations/calls/${update.id}/communications/${callState.id}/metadata`,
-        { method: 'post' }
-      );
-    });
-
-    it('should notify client metadata for persistent connection (new conversation on existing session)', () => {
-      const session = new MockSession() as any as IExtendedMediaSession;
-      session.conversationId = 'old-conversation-id';
-      (session as any)._emittedSessionStarteds = {};
-
-      const callState = {
-        id: 'call-id',
-        state: CommunicationStates.connected,
-        muted: false,
-        confined: false,
-        held: false,
-        direction: 'inbound' as const,
-        provider: 'provider'
-      } as ICallStateFromParticipant;
-
-      const newConversationId = 'new-conversation-id';
-      const participant = {
-        id: 'participants-1',
-        purpose: 'agent',
-        userId,
-        calls: [callState],
-        videos: []
-      } as IConversationParticipantFromEvent;
-
-      const update = new ConversationUpdate({
-        id: newConversationId,
-        participants: [participant]
-      });
-
-      // Set up as if we had a previous alerting state for this conversation
-      const previousCallState = { ...callState, state: CommunicationStates.alerting };
-      const previousParticipant = { ...participant, calls: [previousCallState] };
-      const previousUpdate = new ConversationUpdate({
-        id: newConversationId,
-        participants: [previousParticipant]
-      });
-
-      handler.conversations[newConversationId] = { conversationUpdate: previousUpdate } as any;
-      handler.activeSession = session;
-
-      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
-
-      expect(requestApiSpy).toHaveBeenCalledWith(
-        `/conversations/calls/${newConversationId}/communications/${callState.id}/metadata`,
-        { method: 'post' }
-      );
-    });
-
-    it('should NOT notify client metadata when call transitions to dialing (not yet connected)', () => {
-      const { update, participant, callState, session, previousUpdate } = generateUpdate({
-        callState: CommunicationStates.dialing,
-        previousCallState: { state: CommunicationStates.contacting }
-      });
-
-      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
-      handler.activeSession = session;
-
-      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
-
-      expect(requestApiSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('metadata'),
-        expect.anything()
-      );
-    });
-
-    it('should NOT notify client metadata when no session exists (another client handled it)', () => {
-      const { update, participant, callState, previousUpdate } = generateUpdate({
-        callState: CommunicationStates.connected,
-        previousCallState: { state: CommunicationStates.contacting }
-      });
-
-      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
-
-      handler.handleSoftphoneConversationUpdate(update, participant, callState, undefined);
-
-      expect(requestApiSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('metadata'),
-        expect.anything()
-      );
-    });
-
-    it('should NOT notify client metadata when state is already connected (duplicate update)', () => {
-      const { update, participant, callState, session, previousUpdate } = generateUpdate({
-        callState: CommunicationStates.connected,
-        previousCallState: { state: CommunicationStates.connected }
-      });
-
-      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
-
-      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
-
-      expect(requestApiSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('metadata'),
-        expect.anything()
-      );
-    });
-
-    it('should not block call handling if notifyClientMetadata fails', async () => {
-      requestApiSpy.mockRejectedValue(new Error('network error'));
-
-      const { update, participant, callState, session, previousUpdate } = generateUpdate({
-        callState: CommunicationStates.connected,
-        previousCallState: { state: CommunicationStates.alerting }
-      });
-
-      callState.direction = 'inbound';
-      handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
-      handler.activeSession = session;
-
-      // should not throw
-      handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
-
-      await flushPromises();
-
-      expect(requestApiSpy).toHaveBeenCalledWith(
-        `/conversations/calls/${update.id}/communications/${callState.id}/metadata`,
-        { method: 'post' }
-      );
-      // The error should be logged but not propagated
-      expect(mockSdk.logger.warn).toHaveBeenCalledWith(
-        'failed to notify client metadata',
-        expect.objectContaining({ conversationId: update.id, communicationId: callState.id }),
-        undefined
-      );
-    });
   });
 });
 

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -1598,7 +1598,7 @@ describe('handleSoftphoneConversationUpdate()', () => {
     await flushPromises();
 
     expect(onCancelPendingSessionSpy).toHaveBeenCalledWith(session.id, update.id);
-    expect(forceEndSessionSpy).toHaveBeenCalledWith(session, 'gone');
+    expect(forceEndSessionSpy).toHaveBeenCalledWith(session, 'timeout');
     expect(handler.conversations[update.id]).toBeFalsy();
   });
 
@@ -1643,7 +1643,7 @@ describe('handleSoftphoneConversationUpdate()', () => {
 
     await flushPromises();
 
-    expect(forceEndSessionSpy).toHaveBeenCalledWith(session, 'gone');
+    expect(forceEndSessionSpy).toHaveBeenCalledWith(session, 'timeout');
     expect(logSpy).toHaveBeenCalledWith(
       'error',
       'failed to terminate zombie session',


### PR DESCRIPTION
### MERGE CHECKLIST

- [x] Tests have been updated, added, or removed and the testing matrix has passed.
- [x] Documentation has been updated or added.
- [x] Changelog has been updated with ticket or issue number, link to the ticket, and a description of the changes.
- [x] Branch has been built in the BitBucket wrapper repository.
- [x] Pull request title is formatted as `[STREAM-<ticket number>] - <description of changes>` or `[<issue number>] - <description of changes>`.
- [x] Release pull requests include someone from the PureScale team for approval.
  - [x] Build release branch in wrapper repository and make sure it is tagged with `next` on npm.


### Problem
When establishing a persistent connection (eager privAnswerMode=Auto flow), there's a race condition that creates a zombie WebRTC session:

Client receives propose → sends proceed → receives SDP offer → sends SDP answer
Before ICE completes (peerConnection.connectionState is still 'new' or 'connecting'), the platform sends a conversation update transitioning the call from alerting → disconnected
The SDK processes this as a canceled pending session — removes pending session metadata and deletes the conversation entry
The underlying WebRTC session is never terminated. It remains as this.activeSession with a half-established peer connection
This zombie session causes subsequent calls to fail:

The next persistent connection attempt finds the zombie via this.activeSession and tries to reuse it
The consuming application reads a stale conversationId from the session
API calls fail with 400 "The participant has no active conversation" because they reference the old, dead conversation
Root Cause
In handleSoftphoneConversationUpdate, when a pending call is canceled (previous state was alerting/contacting, new state is disconnected/terminated), the code only cleaned up pending session metadata and the conversations map entry. It never checked whether a real WebRTC session had already been created during signaling and was now stuck in a half-established state.

### Solution
After calling onCancelPendingSession, we now check session.peerConnection.connectionState. If it hasn't reached 'connected' (meaning ICE never completed), we call forceEndSession(session, 'gone') to terminate the zombie. This triggers the terminated event on the session, which cleans up activeSession, sessionsMap, and webrtcSessions — preventing it from being reused by future calls.

If the session is already 'connected', we leave it alone — that's a healthy persistent connection where a logical call was simply canceled before the agent answered, and the transport remains valid for the next call.

