### PR TITLE
[STREAM-1931] Remove `pendingSession` when ignored due to `reducedMedia` configuration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [STREAM-1241](https://inindca.atlassian.net/browse/STREAM-1394) - Prevent redundant pendingSession for already-connected call
 * [STREAM-1789](https://inindca.atlassian.net/browse/STREAM-1789) - Terminate persistent connection sessions that never fully established (ICE never completed) when the pending call is canceled, preventing zombie sessions with stale conversationIds from being reused by future calls.
 * [STREAM-2038](https://inindca.atlassian.net/browse/STREAM-2038) - Added `isEnabled` flag to audio-processor to gate processing. Verify processed stream is different than original stream before swapping audio tracks.
-
+* [STREAM-1931](https://inindca.atlassian.net/browse/STREAM-1931) - When ignoring a `propose` when the SDK is configured for `reducedMedia`, remove the `pendingSession` from tracking so it has a chance to be answered if media handling changes (rather than continuing to be ignored as a duplicate `propose`)
 
 # [v14.2.0](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v14.1.0...v14.2.0)
 ### Fixed

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -169,6 +169,9 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
         }
       } else {
         this.log('info', 'media handling is reduced, but this propose is not marked as autoAnswer and will be ignored', logInfo);
+        // Remove from pendingSessions so a repeat propose has a chance of being answered
+        // if media handling changes in the meantime
+        this.sessionManager.removePendingSession(pendingSession);
         return;
       }
     } else {

--- a/test/integration/media-handling.ts
+++ b/test/integration/media-handling.ts
@@ -1,0 +1,40 @@
+import {
+  SimpleMockSdk,
+  createPendingSession,
+} from '../test-utils';
+import {
+  GenesysCloudWebrtcSdk,
+  MediaHandling,
+  SessionTypes,
+} from '../../src';
+import { SessionManager } from '../../src/sessions/session-manager';
+import SoftphoneSessionHandler from '../../src/sessions/softphone-session-handler';
+
+describe('Media Handling Behavior', () => {
+  let softphoneHandler: SoftphoneSessionHandler;
+  let mockSdk: GenesysCloudWebrtcSdk;
+  let mockSessionManager: SessionManager;
+
+  beforeEach(() => {
+    mockSdk = new SimpleMockSdk() as unknown as GenesysCloudWebrtcSdk;
+    mockSessionManager = new SessionManager(mockSdk);
+    softphoneHandler = new SoftphoneSessionHandler(mockSdk, mockSessionManager);
+    softphoneHandler.disabled = false;
+  });
+
+  it('should allow `pendingSession` to be emitted if media handling changes during repeat `propose`s', async () => {
+    mockSessionManager.sessionHandlers = [softphoneHandler];
+    const sessionInfo = createPendingSession(SessionTypes.softphone);
+    sessionInfo.autoAnswer = false;
+    const pendingSessionSpy = jest.fn();
+    mockSdk.on('pendingSession', pendingSessionSpy);
+
+    mockSdk._mediaHandling = MediaHandling.reducedMedia;
+    await mockSessionManager.onPropose(sessionInfo);
+    expect(pendingSessionSpy).not.toHaveBeenCalled();
+
+    mockSdk._mediaHandling = MediaHandling.alertingLeaderMedia;
+    await mockSessionManager.onPropose(sessionInfo);
+    expect(pendingSessionSpy).toHaveBeenCalled();
+  });
+});

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -91,6 +91,17 @@ describe('handlePropose()', () => {
     expect(superSpyProceed).not.toHaveBeenCalled();
   });
 
+  it('should remove the pendingSession when ignoring due to reducedMedia', async () => {
+    const removePendingSessionSpy = jest.spyOn(mockSessionManager, 'removePendingSession');
+    const pendingSession = createPendingSession(SessionTypes.softphone);
+    pendingSession.autoAnswer = false;
+
+    mockSdk._mediaHandling = MediaHandling.reducedMedia;
+    await handler.handlePropose(pendingSession);
+
+    expect(removePendingSessionSpy).toHaveBeenCalled();
+  });
+
   it('should not autoAnswer if mediaHandling is reducedMedia, autoAnswer is true, but disableAutoAnswer is configured', async () => {
     const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
     const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -91,17 +91,6 @@ describe('handlePropose()', () => {
     expect(superSpyProceed).not.toHaveBeenCalled();
   });
 
-  it('should remove the pendingSession when ignoring due to reducedMedia', async () => {
-    const removePendingSessionSpy = jest.spyOn(mockSessionManager, 'removePendingSession');
-    const pendingSession = createPendingSession(SessionTypes.softphone);
-    pendingSession.autoAnswer = false;
-
-    mockSdk._mediaHandling = MediaHandling.reducedMedia;
-    await handler.handlePropose(pendingSession);
-
-    expect(removePendingSessionSpy).toHaveBeenCalled();
-  });
-
   it('should not autoAnswer if mediaHandling is reducedMedia, autoAnswer is true, but disableAutoAnswer is configured', async () => {
     const superSpyHandlePropose = jest.spyOn(BaseSessionHandler.prototype, 'handlePropose');
     const superSpyProceed = jest.spyOn(BaseSessionHandler.prototype, 'proceedWithSession').mockImplementation();


### PR DESCRIPTION
The symptom being solved here is a call arriving as a client is loading, which looks like it can be answered in the UI, but fails to actually answer.

The following sequence of events can cause this:
- The client is still determining the alerting leader status (and puts the SDK into `reducedMedia`; it also prevents the call from being picked up in the UI).
- The SDK receives a `propose`, which is ignored because it’s in `reducedMedia`.
- The client determines its alerting leader status as Primary and allows the call to be picked up in the UI.
- While there have been repeated `propose`s, they have now been ignored because they are treated as a duplicate `propose`.
- Therefore, the client cannot answer the call because it never learns about the `propose`/`pendingSession` and it cannot tell the SDK to answer.

This PR solves this by removing the `pendingSession` from being tracked if it was ignored due to `reducedMedia`. Then if the `mediaHandling` configuration changes in the future and we get a repeated `propose`, we can treat it like a new `propose` and handle it accordingly.

### MERGE CHECKLIST

- [x] Tests have been updated, added, or removed and the testing matrix has passed.
- [x] Documentation has been updated or added.
- [x] Changelog has been updated with ticket or issue number, link to the ticket, and a description of the changes.
- [x] Branch has been built in the BitBucket wrapper repository.
- [x] Pull request title is formatted as `[STREAM-<ticket number>] - <description of changes>` or `[<issue number>] - <description of changes>`.
- [ ] Release pull requests include someone from the PureScale team for approval.
  - [ ] Build release branch in wrapper repository and make sure it is tagged with `next` on npm.

