### PR TITLE
[STREAM-1974] - Clean up zombie pending sessions when call connects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [STREAM-1968](https://inindca.atlassian.net/browse/STREAM-1968) - New Noise Testing app for the demo app.
 
 ### Fixed
+* [STREAM-1974](https://inindca.atlassian.net/browse/STREAM-1974) - Clean up all pending sessions for a conversationId when a call connects, preventing zombie pending sessions from accumulating during concurrent calls
 * [STREAM-1800](https://inindca.atlassian.net/browse/STREAM-1394) - Dependency bump for `softphone-vendor-headsets` to fix a recent issue with the vendor Yealink
 * [STREAM-1241](https://inindca.atlassian.net/browse/STREAM-1394) - Prevent redundant pendingSession for already-connected call
 * [STREAM-1789](https://inindca.atlassian.net/browse/STREAM-1789) - Terminate persistent connection sessions that never fully established (ICE never completed) when the pending call is canceled, preventing zombie sessions with stale conversationIds from being reused by future calls.

--- a/src/sessions/session-manager.ts
+++ b/src/sessions/session-manager.ts
@@ -116,10 +116,6 @@ export class SessionManager {
     this.pendingSessions = this.pendingSessions.filter(s => s !== pendingSession);
   }
 
-  removePendingSessionsByConversationId (conversationId: string): void {
-    this.pendingSessions = this.pendingSessions.filter(s => s.conversationId !== conversationId);
-  }
-
   getSession (params: { conversationId: string, sessionType?: SessionTypes, searchScreenRecordingSessions?: boolean }): IExtendedMediaSession {
 
     let sessionTypesToSearch: SessionTypes[];

--- a/src/sessions/session-manager.ts
+++ b/src/sessions/session-manager.ts
@@ -116,6 +116,10 @@ export class SessionManager {
     this.pendingSessions = this.pendingSessions.filter(s => s !== pendingSession);
   }
 
+  removePendingSessionsByConversationId (conversationId: string): void {
+    this.pendingSessions = this.pendingSessions.filter(s => s.conversationId !== conversationId);
+  }
+
   getSession (params: { conversationId: string, sessionType?: SessionTypes, searchScreenRecordingSessions?: boolean }): IExtendedMediaSession {
 
     let sessionTypesToSearch: SessionTypes[];

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -373,7 +373,11 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
           // Clean up any remaining pending sessions for this conversationId.
           // This handles the case where a conversation update created a pending session
           // on the active session's ID, but a different session (from propose) actually handled the call.
-          this.sessionManager.removePendingSessionsByConversationId(conversationId);
+          // We route each through onHandledPendingSession so the 'handledPendingSession' event fires
+          // for consumers — a silent filter would swallow the event if this path wins the race.
+          this.sessionManager.pendingSessions
+            .filter(p => p.conversationId === conversationId)
+            .forEach(p => this.sessionManager.onHandledPendingSession(p.id, conversationId));
 
           eventToEmit = 'added';
         }

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -369,6 +369,12 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
             }
             this.sessionManager.onHandledPendingSession(session.id, conversationId);
           }
+
+          // Clean up any remaining pending sessions for this conversationId.
+          // This handles the case where a conversation update created a pending session
+          // on the active session's ID, but a different session (from propose) actually handled the call.
+          this.sessionManager.removePendingSessionsByConversationId(conversationId);
+
           eventToEmit = 'added';
         }
 

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -1556,6 +1556,28 @@ describe('handleSoftphoneConversationUpdate()', () => {
     expect(sdkEmitSpy).not.toHaveBeenCalled();
   });
 
+  it('should remove all pending sessions for a conversationId when call connects (zombie cleanup)', () => {
+    const { update, participant, callState, session, previousUpdate } = generateUpdate({
+      callState: CommunicationStates.connected,
+      previousCallState: { state: CommunicationStates.contacting }
+    });
+
+    handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+    handler.activeSession = session;
+
+    // Simulate the zombie scenario: a pending session was created with the active session's ID
+    // for this conversationId, AND a separate pending session exists from the propose
+    const zombiePendingSession = { id: session.id, conversationId: update.id, sessionType: SessionTypes.softphone } as any;
+    const proposePendingSession = { id: 'propose-session-id', conversationId: update.id, sessionType: SessionTypes.softphone } as any;
+    const unrelatedPendingSession = { id: 'other-id', conversationId: 'other-convo', sessionType: SessionTypes.softphone } as any;
+    mockSessionManager.pendingSessions = [zombiePendingSession, proposePendingSession, unrelatedPendingSession];
+
+    handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+    // Both pending sessions for this conversationId should be removed, but the unrelated one stays
+    expect(mockSessionManager.pendingSessions).toEqual([unrelatedPendingSession]);
+  });
+
   it('should handle pending sessions we rejected', async () => {
     const { update, participant, callState, session, previousUpdate } = generateUpdate({
       callState: CommunicationStates.disconnected,

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -1556,7 +1556,7 @@ describe('handleSoftphoneConversationUpdate()', () => {
     expect(sdkEmitSpy).not.toHaveBeenCalled();
   });
 
-  it('should remove all pending sessions for a conversationId when call connects (zombie cleanup)', () => {
+  it('should emit handledPendingSession for all zombie pending sessions when call connects (conversation update wins race)', () => {
     const { update, participant, callState, session, previousUpdate } = generateUpdate({
       callState: CommunicationStates.connected,
       previousCallState: { state: CommunicationStates.contacting }
@@ -1576,6 +1576,37 @@ describe('handleSoftphoneConversationUpdate()', () => {
 
     // Both pending sessions for this conversationId should be removed, but the unrelated one stays
     expect(mockSessionManager.pendingSessions).toEqual([unrelatedPendingSession]);
+
+    // handledPendingSession should be emitted for BOTH matching pending sessions (not silently filtered)
+    expect(sdkEmitSpy).toHaveBeenCalledWith('handledPendingSession', { sessionId: session.id, conversationId: update.id });
+    expect(sdkEmitSpy).toHaveBeenCalledWith('handledPendingSession', { sessionId: 'propose-session-id', conversationId: update.id });
+  });
+
+  it('should not double-emit handledPendingSession if XMPP stanza already removed the pending session (XMPP wins race)', () => {
+    const { update, participant, callState, session, previousUpdate } = generateUpdate({
+      callState: CommunicationStates.connected,
+      previousCallState: { state: CommunicationStates.contacting }
+    });
+
+    handler.conversations[update.id] = { conversationUpdate: previousUpdate } as any;
+    handler.activeSession = session;
+
+    // Simulate the race condition where the XMPP stanza already handled the propose pending session
+    // (channel 1 won the race), so only the zombie on the active session's ID remains
+    const zombiePendingSession = { id: session.id, conversationId: update.id, sessionType: SessionTypes.softphone } as any;
+    const unrelatedPendingSession = { id: 'other-id', conversationId: 'other-convo', sessionType: SessionTypes.softphone } as any;
+    mockSessionManager.pendingSessions = [zombiePendingSession, unrelatedPendingSession];
+
+    handler.handleSoftphoneConversationUpdate(update, participant, callState, session);
+
+    // Zombie is cleaned up, unrelated stays
+    expect(mockSessionManager.pendingSessions).toEqual([unrelatedPendingSession]);
+
+    // handledPendingSession fires exactly once for the zombie — no double-emit for the already-handled propose session
+    const handledCalls = sdkEmitSpy.mock.calls.filter(([event]: [string]) => event === 'handledPendingSession');
+    expect(handledCalls).toEqual([
+      ['handledPendingSession', { sessionId: session.id, conversationId: update.id }]
+    ]);
   });
 
   it('should handle pending sessions we rejected', async () => {


### PR DESCRIPTION
### MERGE CHECKLIST

- [X] Tests have been updated, added, or removed and the testing matrix has passed.
- [X] Documentation has been updated or added.
- [X] Changelog has been updated with ticket or issue number, link to the ticket, and a description of the changes.
- [x] Branch has been built in the BitBucket wrapper repository.
- [X] Pull request title is formatted as `[STREAM-<ticket number>] - <description of changes>` or `[<issue number>] - <description of changes>`.

## Summary 
Fixes zombie pending sessions accumulating in sessionManager.pendingSessions when agents handle concurrent calls (LA > 1).

## Problem
When a second call arrives on a persistent connection:
  
  1. A conversation update creates a pending session using the active session's ID ({id: 'A', conversationId: 'call-2'})
  2. A propose creates a separate pending session with its own ID ({id: 'B', conversationId: 'call-2'})
  3. When the call connects on session B, onHandledPendingSession('B', 'call-2') removes only the session B entry
  4. The pending session with session A's ID is never cleaned up → zombie
  
  Over a shift with multiple concurrent calls, these zombies accumulate and can cause incorrect pendingSessions.length,
  stale UI state, and potential mis-routing.

## Fix
Added removePendingSessionsByConversationId() to SessionManager and call it after onHandledPendingSession when a call transitions to connected state. This removes all pending sessions for that conversationId regardless of which session ID they were created with.