### PR TITLE
STREAM-1382: Fix group ring webtrc call rejection error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [STREAM-1241](https://inindca.atlassian.net/browse/STREAM-1394) - Prevent redundant pendingSession for already-connected call
 * [STREAM-1789](https://inindca.atlassian.net/browse/STREAM-1789) - Terminate persistent connection sessions that never fully established (ICE never completed) when the pending call is canceled, preventing zombie sessions with stale conversationIds from being reused by future calls.
 * [STREAM-2038](https://inindca.atlassian.net/browse/STREAM-2038) - Added `isEnabled` flag to audio-processor to gate processing. Verify processed stream is different than original stream before swapping audio tracks.
+* [STREAM-1382](https://inindca.atlassian.net/browse/STREAM-1382) - Fixed group ring webtrc call rejection error.
 
 
 # [v14.2.0](https://github.com/MyPureCloud/genesys-cloud-webrtc-sdk/compare/v14.1.0...v14.2.0)

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -765,6 +765,12 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
       participant = await this.fetchUserParticipantFromConversationId(pendingSession.conversationId);
     }
 
+    if (!participant) {
+      throw createAndEmitSdkError.call(this.sdk, SdkErrorTypes.session,
+        'Failed to proceed with session: participant not found for conversationId',
+        { conversationId: pendingSession.conversationId });
+    }
+
     return this.patchPhoneCall(pendingSession.conversationId, participant.id, {
       state: CommunicationStates.connected
     });
@@ -777,6 +783,12 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
 
     if (!participant) {
       participant = await this.fetchUserParticipantFromConversationId(pendingSession.conversationId);
+    }
+
+    if (!participant) {
+      throw createAndEmitSdkError.call(this.sdk, SdkErrorTypes.session,
+        'Failed to reject pending session: participant not found for conversationId',
+        { conversationId: pendingSession.conversationId });
     }
 
     if (participant.purpose === 'user') {

--- a/src/sessions/softphone-session-handler.ts
+++ b/src/sessions/softphone-session-handler.ts
@@ -779,9 +779,13 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
     }
 
     if (!participant) {
-      throw createAndEmitSdkError.call(this.sdk, SdkErrorTypes.session,
-        'Failed to proceed with session: participant not found for conversationId',
-        { conversationId: pendingSession.conversationId });
+      // Participant not yet available on the conversation (race condition in group ring scenarios).
+      // Fall back to XMPP-level proceed which lets the platform handle session setup.
+      this.log('warn', 'participant not found for proceedWithSession, falling back to oRTC proceed', {
+        conversationId: pendingSession.conversationId,
+        sessionId: pendingSession.id
+      });
+      return super.proceedWithSession(pendingSession);
     }
 
     return this.patchPhoneCall(pendingSession.conversationId, participant.id, {
@@ -799,9 +803,13 @@ export class SoftphoneSessionHandler extends BaseSessionHandler {
     }
 
     if (!participant) {
-      throw createAndEmitSdkError.call(this.sdk, SdkErrorTypes.session,
-        'Failed to reject pending session: participant not found for conversationId',
-        { conversationId: pendingSession.conversationId });
+      // Participant not yet available on the conversation (race condition in group ring scenarios).
+      // Fall back to XMPP-level rejection which lets the platform handle routing to the next agent.
+      this.log('warn', 'participant not found for rejectPendingSession, falling back to oRTC reject', {
+        conversationId: pendingSession.conversationId,
+        sessionId: pendingSession.id
+      });
+      return super.rejectPendingSession(pendingSession);
     }
 
     if (participant.purpose === 'user') {

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -873,14 +873,16 @@ describe('proceedWithSession()', () => {
     );
   });
 
-  it('should throw an error if participant cannot be found', async () => {
+  it('should fall back to oRTC proceed if participant cannot be found', async () => {
     getUserParticipantFromConversationEventSpy.mockReturnValue(undefined);
     fetchUserParticipantFromConversationIdSpy.mockResolvedValue(undefined);
 
     handler.activeSession = new MockSession() as any;
     handler.activeSession!.id = pendingSession.id;
 
-    await expect(handler.proceedWithSession(pendingSession)).rejects.toThrow();
+    await handler.proceedWithSession(pendingSession);
+
+    expect(proceedWithSessionSpy).toHaveBeenCalledWith(pendingSession);
     expect(patchPhoneCallSpy).not.toHaveBeenCalled();
   });
 });
@@ -964,14 +966,16 @@ describe('rejectPendingSession()', () => {
     );
   });
 
-  it('should throw an error if participant cannot be found', async () => {
+  it('should fall back to oRTC reject if participant cannot be found', async () => {
     getUserParticipantFromConversationEventSpy.mockReturnValue(undefined);
     fetchUserParticipantFromConversationIdSpy.mockResolvedValue(undefined);
 
     handler.activeSession = new MockSession() as any;
     handler.activeSession!.id = pendingSession.id;
 
-    await expect(handler.rejectPendingSession(pendingSession)).rejects.toThrow();
+    await handler.rejectPendingSession(pendingSession);
+
+    expect(superRejectPendingSessionSpy).toHaveBeenCalledWith(pendingSession);
     expect(patchPhoneCallSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/sessions/softphone-session-handler.test.ts
+++ b/test/unit/sessions/softphone-session-handler.test.ts
@@ -872,6 +872,17 @@ describe('proceedWithSession()', () => {
       { state: CommunicationStates.connected }
     );
   });
+
+  it('should throw an error if participant cannot be found', async () => {
+    getUserParticipantFromConversationEventSpy.mockReturnValue(undefined);
+    fetchUserParticipantFromConversationIdSpy.mockResolvedValue(undefined);
+
+    handler.activeSession = new MockSession() as any;
+    handler.activeSession!.id = pendingSession.id;
+
+    await expect(handler.proceedWithSession(pendingSession)).rejects.toThrow();
+    expect(patchPhoneCallSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('rejectPendingSession()', () => {
@@ -951,6 +962,17 @@ describe('rejectPendingSession()', () => {
       participant.id,
       { state: CommunicationStates.disconnected }
     );
+  });
+
+  it('should throw an error if participant cannot be found', async () => {
+    getUserParticipantFromConversationEventSpy.mockReturnValue(undefined);
+    fetchUserParticipantFromConversationIdSpy.mockResolvedValue(undefined);
+
+    handler.activeSession = new MockSession() as any;
+    handler.activeSession!.id = pendingSession.id;
+
+    await expect(handler.rejectPendingSession(pendingSession)).rejects.toThrow();
+    expect(patchPhoneCallSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
### MERGE CHECKLIST

- [ ] Tests have been updated, added, or removed and the testing matrix has passed.
- [ ] Documentation has been updated or added.
- [ ] Changelog has been updated with ticket or issue number, link to the ticket, and a description of the changes.
- [ ] Branch has been built in the BitBucket wrapper repository.
- [ ] Pull request title is formatted as `[STREAM-<ticket number>] - <description of changes>` or `[<issue number>] - <description of changes>`.
- [ ] Release pull requests include someone from the PureScale team for approval.
  - [ ] Build release branch in wrapper repository and make sure it is tagged with `next` on npm.

Problem
When agents in a sequential ring group are using WebRTC softphones, rejecting an alerting call throws TypeError: Cannot read properties of undefined (reading 'purpose') in rejectPendingSession.

The root cause is a race condition: the XMPP session proposal arrives at the agent before the conversation service has created the participant record on the conversation. When the SDK tries to reject via the REST API, it calls getUserParticipantFromConversationEvent (returns undefined — no cached conversation update yet) then fetchUserParticipantFromConversationId (returns undefined — participant doesn't exist on the API yet). It then accesses participant.purpose on undefined.

Fix
When the participant cannot be resolved, fall back to the XMPP-level rejection (super.rejectPendingSession) which sends Jingle reject messages. This mirrors how SIP phones reject — at the transport layer — and lets the platform handle routing the call to the next agent in the group.

